### PR TITLE
Reference style guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ bundle exec rails s
 
 Visit [localhost:3000](http://localhost:3000).
 
+You can view the style guide at
+[localhost:3000/pages/styleguide](http://localhost:3000/pages/styleguide).
+
 To add a new JavaScript package: `npm install WHATEVER_PACKAGE --save`
 
 ### OAuth in Local Development

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  def render_404
+    render file: Rails.root.join('public', '404'), layout: false,
+           status: :not_found
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,10 @@
 class PagesController < ApplicationController
   def show
-    render template: "pages/#{params[:page]}"
+    case params[:page]
+    when "styleguide"
+      render template: 'pages/styleguide'
+    else
+      render_404
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see
   # http://guides.rubyonrails.org/routing.html
   root to: 'home#index'
-end
 
-Rails.application.routes.draw do
-  get "/pages/:page" => "pages#show"
+  get "/pages/:page" => "pages#show", as: :page
 end


### PR DESCRIPTION
This branch:

- Adds a link to the style guide in the README to let other devs know about it.
- Catches bad page param values so we explicitly render a 404 error when something other than "styleguide" is given. The dynamic template string was making me nervous. 😅 

/cc @smbriones 