### PR TITLE
Make use of anonymous user record when saving compositions

### DIFF
--- a/app/controllers/compositions_controller.rb
+++ b/app/controllers/compositions_controller.rb
@@ -45,7 +45,17 @@ class CompositionsController < ApplicationController
   private
 
   def player
-    @player ||= Player.where(name: params[:player_name]).first_or_initialize
+    return @player if @player
+
+    scope = Player.where(name: params[:player_name])
+    if user_signed_in?
+      scope = scope.where(creator: current_user)
+    else
+      scope = scope.where(creator: User.anonymous,
+                          creator_session_id: session.id)
+    end
+
+    @player = scope.first_or_initialize
   end
 
   def hero

--- a/app/models/composition.rb
+++ b/app/models/composition.rb
@@ -12,7 +12,6 @@ class Composition < ApplicationRecord
   before_validation :set_name
 
   validates :map, :user, :name, presence: true
-  validates :name, uniqueness: { scope: [:map_id, :user_id] }
   validate :session_id_set_if_anonymous
 
   scope :anonymous, ->{ where(user_id: User.anonymous) }

--- a/app/models/composition.rb
+++ b/app/models/composition.rb
@@ -15,6 +15,8 @@ class Composition < ApplicationRecord
   validates :name, uniqueness: { scope: [:map_id, :user_id] }
   validate :session_id_set_if_anonymous
 
+  scope :anonymous, ->{ where(user_id: User.anonymous) }
+
   def set_name
     return unless user
     return if name.present?

--- a/app/models/composition.rb
+++ b/app/models/composition.rb
@@ -11,14 +11,29 @@ class Composition < ApplicationRecord
 
   before_validation :set_name
 
-  validates :map, :session_id, :name, presence: true
+  validates :map, :user, :name, presence: true
   validates :name, uniqueness: { scope: [:map_id, :user_id] }
+  validate :session_id_set_if_anonymous
 
   def set_name
     return unless user
     return if name.present?
 
-    num_comps = user.compositions.count
+    num_comps = if user.anonymous?
+      Composition.where(session_id: session_id).count
+    else
+      user.compositions.count
+    end
+
     self.name = "Composition #{num_comps + 1}"
+  end
+
+  private
+
+  def session_id_set_if_anonymous
+    return unless user && user.anonymous?
+    return if session_id.present?
+
+    errors.add(:session_id, 'is required if user is anonymous.')
   end
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,7 +1,18 @@
 class Player < ApplicationRecord
   belongs_to :user
+  belongs_to :creator, class_name: 'User'
 
   has_many :player_heroes, dependent: :destroy
 
-  validates :name, presence: true
+  validates :name, :creator, presence: true
+  validate :creator_session_id_set_if_anonymous
+
+  private
+
+  def creator_session_id_set_if_anonymous
+    return unless creator && creator.anonymous?
+    return if creator_session_id.present?
+
+    errors.add(:creator_session_id, 'is required if creator is anonymous user.')
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,16 @@ class User < ApplicationRecord
 
   has_many :compositions, dependent: :destroy
 
+  ANONYMOUS_EMAIL = 'anonymous@overwatch-team-comps.com'.freeze
+
+  # Returns the special User for representing anonymous site visitors.
   def self.anonymous
-    find_by_email "anonymous@overwatch-team-comps.com"
+    find_by_email ANONYMOUS_EMAIL
+  end
+
+  # Returns true if this User is the special User that represents an anonymous visitor
+  # to the site.
+  def anonymous?
+    email == ANONYMOUS_EMAIL
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   devise :omniauthable, omniauth_providers: [:bnet]
 
   has_many :compositions, dependent: :destroy
+  has_many :created_players, class_name: 'Player', foreign_key: 'creator_id'
 
   ANONYMOUS_EMAIL = 'anonymous@overwatch-team-comps.com'.freeze
 

--- a/db/migrate/20170310230642_add_creator_info_to_players.rb
+++ b/db/migrate/20170310230642_add_creator_info_to_players.rb
@@ -1,0 +1,8 @@
+class AddCreatorInfoToPlayers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :players, :creator_id, :integer, null: false
+    add_index :players, :creator_id
+
+    add_column :players, :creator_session_id, :string, limit: 32
+  end
+end

--- a/db/migrate/20170310233529_change_session_id_null.rb
+++ b/db/migrate/20170310233529_change_session_id_null.rb
@@ -1,0 +1,5 @@
+class ChangeSessionIdNull < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :compositions, :session_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170308042755) do
+ActiveRecord::Schema.define(version: 20170310230642) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "compositions", force: :cascade do |t|
-    t.string   "name",       null: false
+    t.string   "name",                               null: false
     t.text     "notes"
     t.integer  "map_id",                             null: false
     t.integer  "user_id",                            null: false
@@ -75,11 +75,14 @@ ActiveRecord::Schema.define(version: 20170308042755) do
   end
 
   create_table "players", force: :cascade do |t|
-    t.string   "name",       null: false
+    t.string   "name",                          null: false
     t.string   "battletag"
     t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.integer  "creator_id",                    null: false
+    t.string   "creator_session_id", limit: 32
+    t.index ["creator_id"], name: "index_players_on_creator_id", using: :btree
     t.index ["user_id"], name: "index_players_on_user_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170310230642) do
+ActiveRecord::Schema.define(version: 20170310233529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 20170310230642) do
     t.datetime "created_at",                         null: false
     t.datetime "updated_at",                         null: false
     t.string   "video_url",             default: ""
-    t.string   "session_id", limit: 32,              null: false
+    t.string   "session_id", limit: 32
     t.index ["map_id"], name: "index_compositions_on_map_id", using: :btree
     t.index ["user_id"], name: "index_compositions_on_user_id", using: :btree
   end

--- a/spec/controllers/compositions_controller_spec.rb
+++ b/spec/controllers/compositions_controller_spec.rb
@@ -41,6 +41,15 @@ RSpec.describe CompositionsController do
       end.to change { Composition.count }.by(1)
     end
 
+    it 'creates a new composition for anonymous user' do
+      expect do
+        post :save, params: {
+          player_name: 'FabulousPrizes', hero_id: @hero1.id,
+          map_segment_id: @map_segment.id, format: :json
+        }
+      end.to change { @anon_user.compositions.count }.by(1)
+    end
+
     it 'creates a new player for new name for authenticated user' do
       sign_in @user
 
@@ -50,6 +59,15 @@ RSpec.describe CompositionsController do
           map_segment_id: @map_segment.id, format: :json
         }
       end.to change { Player.count }.by(1)
+    end
+
+    it 'creates a new player for new name for anonymous user' do
+      expect do
+        post :save, params: {
+          player_name: 'NiftyThrifty618', hero_id: @hero1.id,
+          map_segment_id: @map_segment.id, format: :json
+        }
+      end.to change { @anon_user.created_players.count }.by(1)
     end
 
     it 'reuses existing player for authenticated user' do

--- a/spec/controllers/compositions_controller_spec.rb
+++ b/spec/controllers/compositions_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe CompositionsController do
+  before(:each) do
+    @user = create(:user)
+    @anon_user = create(:anonymous_user)
+    @map = create(:map)
+    @map_segment = create(:map_segment, map: @map)
+    @hero1 = create(:hero, name: 'Mei')
+    @hero2 = create(:hero, name: 'Soldier: 76')
+
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+
+  describe 'POST save' do
+    it 'loads successfully for authenticated user' do
+      sign_in @user
+      post :save, params: {
+        player_name: 'chocotaco', hero_id: @hero1.id,
+        map_segment_id: @map_segment.id, format: :json
+      }
+      expect(response).to be_success, response.body
+    end
+
+    it 'loads successfully for anonymous user' do
+      post :save, params: {
+        player_name: 'practicalLlama', hero_id: @hero1.id,
+        map_segment_id: @map_segment.id, format: :json
+      }
+      expect(response).to be_success, response.body
+    end
+  end
+end

--- a/spec/controllers/compositions_controller_spec.rb
+++ b/spec/controllers/compositions_controller_spec.rb
@@ -29,5 +29,92 @@ RSpec.describe CompositionsController do
       }
       expect(response).to be_success, response.body
     end
+
+    it 'creates a new composition for authenticated user' do
+      sign_in @user
+
+      expect do
+        post :save, params: {
+          player_name: 'chocotaco', hero_id: @hero1.id,
+          map_segment_id: @map_segment.id, format: :json
+        }
+      end.to change { Composition.count }.by(1)
+    end
+
+    it 'creates a new player for new name for authenticated user' do
+      sign_in @user
+
+      expect do
+        post :save, params: {
+          player_name: 'chocotaco', hero_id: @hero1.id,
+          map_segment_id: @map_segment.id, format: :json
+        }
+      end.to change { Player.count }.by(1)
+    end
+
+    it 'reuses existing player for authenticated user' do
+      sign_in @user
+      player = create(:player, creator: @user)
+
+      expect do
+        post :save, params: {
+          player_name: player.name, hero_id: @hero1.id,
+          map_segment_id: @map_segment.id, format: :json
+        }
+      end.not_to change { Player.count }
+    end
+
+    it 'creates a new player-hero for new combination for auth user' do
+      sign_in @user
+
+      expect do
+        post :save, params: {
+          player_name: 'chocotaco', hero_id: @hero1.id,
+          map_segment_id: @map_segment.id, format: :json
+        }
+      end.to change { PlayerHero.count }.by(1)
+    end
+
+    it 'reuses an existing player-hero combination for auth user' do
+      sign_in @user
+      player = create(:player, creator: @user)
+      player_hero = create(:player_hero, player: player, hero: @hero1)
+
+      expect do
+        post :save, params: {
+          player_name: player.name, hero_id: @hero1.id,
+          map_segment_id: @map_segment.id, format: :json
+        }
+      end.not_to change { PlayerHero.count }
+    end
+
+    it 'creates a new player selection for authenticated user' do
+      sign_in @user
+
+      expect do
+        post :save, params: {
+          player_name: 'chocotaco', hero_id: @hero1.id,
+          map_segment_id: @map_segment.id, format: :json
+        }
+      end.to change { PlayerSelection.count }.by(1)
+    end
+
+    it 'no-op for existing player selection for authenticated user' do
+      sign_in @user
+
+      player = create(:player, creator: @user)
+      player_hero = create(:player_hero, player: player, hero: @hero1)
+      composition = create(:composition, user: @user, map: @map)
+      player_selection = create(:player_selection, composition: composition,
+                                player_hero: player_hero,
+                                map_segment: @map_segment)
+
+      expect do
+        post :save, params: {
+          player_name: player.name, hero_id: @hero1.id, format: :json,
+          composition_id: composition.id, map_segment_id: @map_segment.id
+        }
+      end.not_to change { PlayerSelection.count }
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -5,9 +5,8 @@ FactoryGirl.define do
   end
 
   factory :composition do
-    map
+    map { Map.first || create(:map) }
     user
-    session_id '123abc'
   end
 
   factory :hero do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -27,6 +27,7 @@ FactoryGirl.define do
 
   factory :player do
     name 'zion'
+    association :creator, factory: :user
   end
 
   factory :player_hero do
@@ -42,10 +43,10 @@ FactoryGirl.define do
   end
 
   factory :user do
-    email 'jimbob@example.com'
+    email { "jimbob#{User.count}@example.com" }
     password '123abcCatDog!'
     provider 'bnet'
-    uid '123456'
-    battletag 'jimbob#1234'
+    uid { "123456#{User.count}" }
+    battletag { "jimbob#123#{User.count}" }
   end
 end

--- a/spec/models/composition_spec.rb
+++ b/spec/models/composition_spec.rb
@@ -28,10 +28,35 @@ describe Composition do
     expect(composition.name).not_to be_nil
   end
 
-  it 'requires a unique name per user + map combo' do
+  it 'sets composition name for anonymous user scoped by session' do
+    anon_user = create(:anonymous_user)
+
+    session1 = '123abc'
+    session2 = '987zyx'
+
+    session1_comp = create(:composition, user: anon_user, session_id: session1)
+    expect(session1_comp.name).to eq('Composition 1')
+
+    session2_comp = create(:composition, user: anon_user, session_id: session2)
+    expect(session2_comp.name).to eq('Composition 1')
+
+    session1_comp2 = build(:composition, user: anon_user, session_id: session1)
+    session1_comp2.valid?
+    expect(session1_comp2.name).to eq('Composition 2')
+  end
+
+  it 'requires a unique name per user for authenticated user' do
     existing = create(:composition)
-    composition = Composition.new(name: existing.name, map: existing.map,
-                                  user: existing.user)
+    composition = Composition.new(name: existing.name, user: existing.user)
+    expect(composition.valid?).to be_falsey
+    expect(composition.errors[:name].any?).to be_truthy
+  end
+
+  it 'requires a unique name per user for anonymous user' do
+    anon_user = create(:anonymous_user)
+    existing = create(:composition, user: anon_user, session_id: '123abc')
+    composition = Composition.new(name: existing.name, user: existing.user,
+                                  session_id: existing.session_id)
     expect(composition.valid?).to be_falsey
     expect(composition.errors[:name].any?).to be_truthy
   end

--- a/spec/models/composition_spec.rb
+++ b/spec/models/composition_spec.rb
@@ -7,6 +7,19 @@ describe Composition do
     expect(composition.errors[:map].any?).to be_truthy
   end
 
+  it 'requires a user' do
+    composition = Composition.new
+    expect(composition.valid?).to be_falsey
+    expect(composition.errors[:user].any?).to be_truthy
+  end
+
+  it 'requires a session ID if the user is anonymous' do
+    anon_user = create(:anonymous_user)
+    composition = Composition.new(user: anon_user)
+    expect(composition.valid?).to be_falsey
+    expect(composition.errors[:session_id].any?).to be_truthy
+  end
+
   it 'sets composition name before validation' do
     user = create(:user)
     composition = Composition.new(user: user)

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -6,4 +6,17 @@ describe Player do
     expect(player.valid?).to be_falsey
     expect(player.errors[:name].any?).to be_truthy
   end
+
+  it 'requires a creator' do
+    player = Player.new
+    expect(player.valid?).to be_falsey
+    expect(player.errors[:creator].any?).to be_truthy
+  end
+
+  it 'requires a creator session ID if the creator is anonymous' do
+    anon_user = create(:anonymous_user)
+    player = Player.new(creator: anon_user)
+    expect(player.valid?).to be_falsey
+    expect(player.errors[:creator_session_id].any?).to be_truthy
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'factory_girl_rails'
+require 'devise'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -34,6 +35,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   config.include RequestSpecHelper, type: :request
+  config.include Devise::Test::ControllerHelpers, type: :controller
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/requests/compositions_api_spec.rb
+++ b/spec/requests/compositions_api_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'compositions API' do
 
     it 'reuses existing player' do
       sign_in @user
-      player = create(:player)
+      player = create(:player, creator: @user)
 
       expect do
         post '/api/compositions', params: {
@@ -84,7 +84,7 @@ RSpec.describe 'compositions API' do
 
     it 'reuses an existing player-hero combination' do
       sign_in @user
-      player = create(:player)
+      player = create(:player, creator: @user)
       player_hero = create(:player_hero, player: player, hero: @hero1)
 
       expect do
@@ -122,7 +122,7 @@ RSpec.describe 'compositions API' do
     it 'no-op for existing player selection' do
       sign_in @user
 
-      player = create(:player)
+      player = create(:player, creator: @user)
       player_hero = create(:player_hero, player: player, hero: @hero1)
       composition = create(:composition, user: @user, map: @map)
       player_selection = create(:player_selection, composition: composition,

--- a/spec/requests/compositions_api_spec.rb
+++ b/spec/requests/compositions_api_spec.rb
@@ -10,61 +10,50 @@ RSpec.describe 'compositions API' do
   end
 
   describe 'POST save' do
-    it 'creates a new composition' do
+    it 'returns new composition info for authenticated user' do
       sign_in @user
-
-      expect do
-        post '/api/compositions', params: {
-          player_name: 'chocotaco', hero_id: @hero1.id,
-          map_segment_id: @map_segment.id
-        }
-      end.to change { Composition.count }.by(1)
+      post '/api/compositions', params: {
+        player_name: 'chocotaco', hero_id: @hero1.id,
+        map_segment_id: @map_segment.id
+      }
 
       json = JSON.parse(response.body)
       expect(json).to have_key('composition')
       expect(json['composition']['map']['name']).to eq(@map.name)
     end
 
-    it 'creates a new player for new name' do
+    it 'returns new player info for authenticated user' do
       sign_in @user
-
-      expect do
-        post '/api/compositions', params: {
-          player_name: 'chocotaco', hero_id: @hero1.id,
-          map_segment_id: @map_segment.id
-        }
-      end.to change { Player.count }.by(1)
+      post '/api/compositions', params: {
+        player_name: 'chocotaco', hero_id: @hero1.id,
+        map_segment_id: @map_segment.id
+      }
 
       json = JSON.parse(response.body)
       expect(json).to have_key('composition')
       expect(json['composition']['players'][0]['name']).to eq('chocotaco')
     end
 
-    it 'reuses existing player' do
+    it 'returns existing player info for authenticated user' do
       sign_in @user
       player = create(:player, creator: @user)
 
-      expect do
-        post '/api/compositions', params: {
-          player_name: player.name, hero_id: @hero1.id,
-          map_segment_id: @map_segment.id
-        }
-      end.not_to change { Player.count }
+      post '/api/compositions', params: {
+        player_name: player.name, hero_id: @hero1.id,
+        map_segment_id: @map_segment.id
+      }
 
       json = JSON.parse(response.body)
       expect(json).to have_key('composition')
       expect(json['composition']['players'][0]['name']).to eq(player.name)
     end
 
-    it 'creates a new player-hero for new combination' do
+    it 'returns new player-hero info for new combination for auth user' do
       sign_in @user
-
-      expect do
-        post '/api/compositions', params: {
-          player_name: 'chocotaco', hero_id: @hero1.id,
-          map_segment_id: @map_segment.id
-        }
-      end.to change { PlayerHero.count }.by(1)
+      post '/api/compositions', params: {
+        player_name: 'chocotaco', hero_id: @hero1.id,
+        map_segment_id: @map_segment.id
+      }
 
       json = JSON.parse(response.body)
       expect(json).to have_key('composition')
@@ -73,17 +62,15 @@ RSpec.describe 'compositions API' do
       expect(json['composition']['players'][0]['heroes'][0]['name']).to eq(@hero1.name)
     end
 
-    it 'reuses an existing player-hero combination' do
+    it 'returns existing player-hero combination for auth user' do
       sign_in @user
       player = create(:player, creator: @user)
       player_hero = create(:player_hero, player: player, hero: @hero1)
 
-      expect do
-        post '/api/compositions', params: {
-          player_name: player.name, hero_id: @hero1.id,
-          map_segment_id: @map_segment.id
-        }
-      end.not_to change { PlayerHero.count }
+      post '/api/compositions', params: {
+        player_name: player.name, hero_id: @hero1.id,
+        map_segment_id: @map_segment.id
+      }
 
       json = JSON.parse(response.body)
       expect(json).to have_key('composition')
@@ -92,7 +79,7 @@ RSpec.describe 'compositions API' do
       expect(json['composition']['players'][0]['heroes'][0]['name']).to eq(@hero1.name)
     end
 
-    it 'creates a new player selection' do
+    it 'returns new player selection for authenticated user' do
       sign_in @user
 
       expect do
@@ -110,7 +97,7 @@ RSpec.describe 'compositions API' do
       expect(json['composition']['players'][0]['selectedHero']['name']).to eq(@hero1.name)
     end
 
-    it 'no-op for existing player selection' do
+    it 'no-op for existing player selection for authenticated user' do
       sign_in @user
 
       player = create(:player, creator: @user)
@@ -120,12 +107,10 @@ RSpec.describe 'compositions API' do
                                 player_hero: player_hero,
                                 map_segment: @map_segment)
 
-      expect do
-        post '/api/compositions', params: {
-          player_name: player.name, hero_id: @hero1.id,
-          composition_id: composition.id, map_segment_id: @map_segment.id
-        }
-      end.not_to change { PlayerSelection.count }
+      post '/api/compositions', params: {
+        player_name: player.name, hero_id: @hero1.id,
+        composition_id: composition.id, map_segment_id: @map_segment.id
+      }
 
       json = JSON.parse(response.body)
       expect(json).to have_key('composition')

--- a/spec/requests/compositions_api_spec.rb
+++ b/spec/requests/compositions_api_spec.rb
@@ -10,15 +10,6 @@ RSpec.describe 'compositions API' do
   end
 
   describe 'POST save' do
-    it 'loads successfully for authenticated user' do
-      sign_in @user
-      post '/api/compositions', params: {
-        player_name: 'chocotaco', hero_id: @hero1.id,
-        map_segment_id: @map_segment.id
-      }
-      expect(response).to be_success, response.body
-    end
-
     it 'creates a new composition' do
       sign_in @user
 


### PR DESCRIPTION
This makes use of the anonymous user record added in #47 when hitting the /api/compositions/save endpoint. It also ties each Player record back to the User who created it, even if that user was anonymous. It adds validations such that we will always have a saved session ID for players and compositions when the user is not signed in.

Tests are green:

```
% be rspec
................................................

Finished in 1.93 seconds (files took 2.59 seconds to load)
48 examples, 0 failures
```