### PR TITLE
Save player names as the user changes them

### DIFF
--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -69,7 +69,6 @@ export default class CompositionForm extends React.Component {
       body.composition_id = composition.id
     }
 
-    console.log(body)
     api.saveComposition(body).
       then(newComp => this.onCompositionSaved(newComp)).
       catch(err => CompositionForm.onCompositionSaveError(err))

--- a/app/assets/javascripts/components/edit-player-selection-row.jsx
+++ b/app/assets/javascripts/components/edit-player-selection-row.jsx
@@ -1,19 +1,10 @@
-import { debounce } from 'throttle-debounce'
+import DebounceInput from 'react-debounce-input'
 
 import HeroSelect from './hero-select.jsx'
 
 class EditPlayerSelectionRow extends React.Component {
-  constructor(props) {
-    super(props)
-    this.onPlayerNameChange = debounce(500, this.onPlayerNameChange)
-  }
-
-  onPlayerNameChange(name) {
-    this.props.onPlayerNameChange(name)
-  }
-
-  onPlayerNameKeyUp(event) {
-    this.onPlayerNameChange(event.target.value)
+  onPlayerNameChange(event) {
+    this.props.onPlayerNameChange(event.target.value)
   }
 
   getSelectedHeroID(segment) {
@@ -36,13 +27,13 @@ class EditPlayerSelectionRow extends React.Component {
             htmlFor={inputID}
             className="label"
           >{nameLabel}</label>
-          <input
-            type="text"
+          <DebounceInput
+            debounceTimeout={500}
+            onChange={e => this.onPlayerNameChange(e)}
             id={inputID}
             placeholder="Player name"
-            defaultValue={player.name}
+            value={player.name}
             className="input"
-            onKeyUp={this.onPlayerNameKeyUp.bind(this)}
           />
         </td>
         {mapSegments.map(segment => (

--- a/app/assets/javascripts/components/edit-player-selection-row.jsx
+++ b/app/assets/javascripts/components/edit-player-selection-row.jsx
@@ -10,7 +10,9 @@ class EditPlayerSelectionRow extends React.Component {
   getSelectedHeroID(segment) {
     const needle = segment.id
     const haystack = this.props.player.heroes
-    const heroes = haystack.filter(hero => hero.mapSegmentID === needle)
+    const heroes = haystack.filter(hero =>
+      hero.mapSegmentIDs && hero.mapSegmentIDs.indexOf(needle) > -1
+    )
     if (heroes.length > 0) {
       return heroes[0].id
     }

--- a/app/assets/javascripts/models/overwatch-team-comps-api.js
+++ b/app/assets/javascripts/models/overwatch-team-comps-api.js
@@ -22,7 +22,7 @@ export default class OverwatchTeamCompsApi extends Fetcher {
       then(json => json.composition)
   }
 
-  savePlayerSelection(body) {
+  saveComposition(body) {
     return this.post('/compositions', this.defaultHeaders, body).
       then(json => json.composition)
   }

--- a/app/controllers/compositions_controller.rb
+++ b/app/controllers/compositions_controller.rb
@@ -40,7 +40,7 @@ class CompositionsController < ApplicationController
 
   def composition_params
     params.permit(:player_name, :composition_id, :hero_id, :map_segment_id,
-                  :player_id, :player_position)
+                  :player_id, :player_position, :map_id)
   end
 
   def get_map_segment_ids(heroes, composition)

--- a/app/controllers/compositions_controller.rb
+++ b/app/controllers/compositions_controller.rb
@@ -63,9 +63,9 @@ class CompositionsController < ApplicationController
 
   def get_players_for(composition)
     players = []
-    players.concat(composition.players.uniq) if composition.persisted?
+    players.concat(composition.players) if composition.persisted?
 
-    existing_names = players.map(&:name)
+    existing_names = players.pluck(:name)
     while players.length < Composition::MAX_PLAYERS
       name = Player.get_name(existing_names)
       players << Player.new(name: name)

--- a/app/controllers/compositions_controller.rb
+++ b/app/controllers/compositions_controller.rb
@@ -12,9 +12,8 @@ class CompositionsController < ApplicationController
 
   def save
     saver = CompositionSaver.new(user: current_user, session_id: session.id)
-    if saver.save(composition_params)
-    else
-      render json: {
+    unless saver.save(composition_params)
+      return render json: {
         "#{saver.error_type}_errors" => saver.error_value
       }, status: :unprocessable_entity
     end
@@ -43,10 +42,10 @@ class CompositionsController < ApplicationController
     end
 
     player_selections = composition.player_selections.
-      includes(player_hero: :player)
+      includes(:player)
     player_selections.each do |player_selection|
-      hero_id = player_selection.player_hero.hero_id
-      player_name = player_selection.player_hero.player.name
+      hero_id = player_selection.hero_id
+      player_name = player_selection.player.name
       result[hero_id][player_name] = player_selection.map_segment_id
     end
 

--- a/app/controllers/compositions_controller.rb
+++ b/app/controllers/compositions_controller.rb
@@ -12,7 +12,7 @@ class CompositionsController < ApplicationController
 
   def save
     saver = CompositionSaver.new(user: current_user, session_id: session.id)
-    if saver.save(params)
+    if saver.save(composition_params)
     else
       render json: {
         "#{saver.error_type}_errors" => saver.error_value
@@ -29,6 +29,10 @@ class CompositionsController < ApplicationController
   end
 
   private
+
+  def composition_params
+    params.permit(:player_name, :composition_id, :hero_id, :map_segment_id)
+  end
 
   def get_map_segment_ids(heroes, composition)
     result = {}

--- a/app/controllers/compositions_controller.rb
+++ b/app/controllers/compositions_controller.rb
@@ -31,7 +31,8 @@ class CompositionsController < ApplicationController
   private
 
   def composition_params
-    params.permit(:player_name, :composition_id, :hero_id, :map_segment_id)
+    params.permit(:player_name, :composition_id, :hero_id, :map_segment_id,
+                  :player_id)
   end
 
   def get_map_segment_ids(heroes, composition)

--- a/app/controllers/compositions_controller.rb
+++ b/app/controllers/compositions_controller.rb
@@ -40,7 +40,7 @@ class CompositionsController < ApplicationController
 
   def composition_params
     params.permit(:player_name, :composition_id, :hero_id, :map_segment_id,
-                  :player_id)
+                  :player_id, :player_position)
   end
 
   def get_map_segment_ids(heroes, composition)

--- a/app/controllers/compositions_controller.rb
+++ b/app/controllers/compositions_controller.rb
@@ -55,7 +55,8 @@ class CompositionsController < ApplicationController
     player_selections.each do |player_selection|
       hero_id = player_selection.hero_id
       player_name = player_selection.player.name
-      result[hero_id][player_name] = player_selection.map_segment_id
+      result[hero_id][player_name] ||= []
+      result[hero_id][player_name] << player_selection.map_segment_id
     end
 
     result

--- a/app/controllers/compositions_controller.rb
+++ b/app/controllers/compositions_controller.rb
@@ -11,27 +11,15 @@ class CompositionsController < ApplicationController
   end
 
   def save
-    unless player.persisted? || player.save
-      return render json: { player_errors: player.errors },
-                    status: :unprocessable_entity
+    saver = CompositionSaver.new(user: current_user, session_id: session.id)
+    if saver.save(params)
+    else
+      render json: {
+        "#{saver.error_type}_errors" => saver.error_value
+      }, status: :unprocessable_entity
     end
 
-    unless player_hero.persisted? || player_hero.save
-      return render json: { player_hero_errors: player_hero.errors },
-                    status: :unprocessable_entity
-    end
-
-    unless composition.persisted? || composition.save
-      return render json: { composition_errors: composition.errors },
-                    status: :unprocessable_entity
-    end
-
-    unless player_selection.persisted? || player_selection.save
-      return render json: { player_selection_errors: player_selection.errors },
-                    status: :unprocessable_entity
-    end
-
-    @composition = composition
+    @composition = saver.composition
     @players = get_players_for(@composition)
 
     heroes = Hero.order(:name)
@@ -110,45 +98,6 @@ class CompositionsController < ApplicationController
     result
   end
 
-  def player
-    return @player if @player
-
-    scope = Player.where(name: params[:player_name])
-    if user_signed_in?
-      scope = scope.where(creator: current_user)
-    else
-      scope = scope.where(creator: User.anonymous,
-                          creator_session_id: session.id)
-    end
-
-    @player = scope.first_or_initialize
-  end
-
-  def hero
-    return @hero if defined? @hero
-    @hero = Hero.find(params[:hero_id])
-  end
-
-  def player_hero
-    return @player_hero if @player_hero
-    return @player_hero = nil unless hero && player.persisted?
-
-    @player_hero = PlayerHero.where(player_id: player, hero_id: hero).
-      first_or_initialize
-  end
-
-  def map_segment
-    return @map_segment if defined? @map_segment
-    @map_segment = MapSegment.find(params[:map_segment_id])
-  end
-
-  def map
-    return @map if defined? @map
-    @map = if map_segment
-      map_segment.map
-    end
-  end
-
   def new_composition
     map = Map.first
 
@@ -156,43 +105,6 @@ class CompositionsController < ApplicationController
       Composition.new(map: map, user: current_user)
     else
       Composition.new(map: map, user: User.anonymous, session_id: session.id)
-    end
-  end
-
-  def composition
-    return @composition if defined? @composition
-
-    @composition = if user_signed_in?
-      composition_for_authenticated_user
-    else
-      composition_for_anonymous_user
-    end
-  end
-
-  def composition_for_authenticated_user
-    if id = params[:composition_id]
-      Composition.where(id: id, user_id: current_user).first
-    else
-      Composition.new(map: map, user: current_user)
-    end
-  end
-
-  def composition_for_anonymous_user
-    if id = params[:composition_id]
-      Composition.where(id: id, user_id: User.anonymous,
-                        session_id: session.id).first
-    else
-      Composition.new(map: map, session_id: session.id, user: User.anonymous)
-    end
-  end
-
-  def player_selection
-    @player_selection ||= if composition.persisted?
-      PlayerSelection.where(composition_id: composition,
-                            player_hero_id: player_hero,
-                            map_segment_id: map_segment).first_or_initialize
-    else
-      PlayerSelection.new(player_hero: player_hero, map_segment: map_segment)
     end
   end
 end

--- a/app/controllers/compositions_controller.rb
+++ b/app/controllers/compositions_controller.rb
@@ -12,9 +12,18 @@ class CompositionsController < ApplicationController
 
   def save
     saver = CompositionSaver.new(user: current_user, session_id: session.id)
-    unless saver.save(composition_params)
+
+    success = begin
+      saver.save(composition_params)
+    rescue CompositionSaver::Error => ex
+      return render json: { error: ex.message }, status: :bad_request
+    end
+
+    unless success
       return render json: {
-        "#{saver.error_type}_errors" => saver.error_value
+        error: {
+          saver.error_type => saver.error_value.full_messages
+        }
       }, status: :unprocessable_entity
     end
 

--- a/app/models/composition.rb
+++ b/app/models/composition.rb
@@ -4,8 +4,10 @@ class Composition < ApplicationRecord
   belongs_to :map
   belongs_to :user
 
+  has_many :composition_players, dependent: :destroy
+  has_many :players, through: :composition_players
+
   has_many :player_selections, dependent: :destroy
-  has_many :players, through: :player_selections
   has_many :heroes, through: :player_selections
 
   before_validation :set_name

--- a/app/models/composition.rb
+++ b/app/models/composition.rb
@@ -5,9 +5,8 @@ class Composition < ApplicationRecord
   belongs_to :user
 
   has_many :player_selections, dependent: :destroy
-  has_many :player_heroes, through: :player_selections
-  has_many :players, through: :player_heroes
-  has_many :heroes, through: :player_heroes
+  has_many :players, through: :player_selections
+  has_many :heroes, through: :player_selections
 
   before_validation :set_name
 

--- a/app/models/composition_player.rb
+++ b/app/models/composition_player.rb
@@ -6,12 +6,26 @@ class CompositionPlayer < ApplicationRecord
 
   validates :player, :composition, :position, presence: true
   validates :position, numericality: { only_integer: true }
+  validate :composition_does_not_have_max_players
 
   default_scope { order(:position) }
 
   private
 
   def set_position
+    return unless composition
+
     self.position ||= composition.composition_players.count
+  end
+
+  def composition_does_not_have_max_players
+    return unless composition
+
+    scope = composition.composition_players
+    scope = scope.where('id <> ?', id) if persisted?
+
+    if scope.count > Composition::MAX_PLAYERS - 1
+      errors.add(:composition, 'has maximum number of players already.')
+    end
   end
 end

--- a/app/models/composition_player.rb
+++ b/app/models/composition_player.rb
@@ -1,0 +1,17 @@
+class CompositionPlayer < ApplicationRecord
+  belongs_to :composition
+  belongs_to :player
+
+  before_validation :set_position
+
+  validates :player, :composition, :position, presence: true
+  validates :position, numericality: { only_integer: true }
+
+  default_scope { order(:position) }
+
+  private
+
+  def set_position
+    self.position ||= composition.composition_players.count
+  end
+end

--- a/app/models/composition_saver.rb
+++ b/app/models/composition_saver.rb
@@ -93,6 +93,9 @@ class CompositionSaver
         scope = scope.where(user_id: User.anonymous, session_id: @session_id)
       end
       comp = scope.first
+      unless comp
+        raise CompositionSaver::Error, 'No such composition for creator'
+      end
       comp.map = map if map
       comp
     else

--- a/app/models/composition_saver.rb
+++ b/app/models/composition_saver.rb
@@ -18,9 +18,11 @@ class CompositionSaver
       end
     end
 
-    if data[:map_segment_id]
+    map = if data[:map_segment_id]
       map_segment = MapSegment.find(data[:map_segment_id])
-      map = map_segment.map
+      map_segment.map
+    elsif data[:map_id]
+      Map.find(data[:map_id])
     end
 
     if data[:composition_id] || map

--- a/app/models/composition_saver.rb
+++ b/app/models/composition_saver.rb
@@ -1,6 +1,8 @@
 class CompositionSaver
   attr_reader :error_type, :error_value, :composition
 
+  class Error < StandardError; end
+
   def initialize(user:, session_id:)
     @user = user
     @session_id = session_id
@@ -55,6 +57,9 @@ class CompositionSaver
                             creator_session_id: @session_id)
       end
       player = scope.first
+      unless player
+        raise CompositionSaver::Error, 'No such player for creator'
+      end
       player.name = data[:player_name]
       player
     else

--- a/app/models/composition_saver.rb
+++ b/app/models/composition_saver.rb
@@ -32,6 +32,16 @@ class CompositionSaver
       end
     end
 
+    if player && @composition
+      comp_player = init_composition_player(data, player: player,
+                                            composition: @composition)
+      unless comp_player.persisted? || comp_player.save
+        @error_type = 'composition_player'
+        @error_value = comp_player.errors
+        return
+      end
+    end
+
     if player && map_segment && data[:hero_id]
       selection = init_player_selection(data, composition: @composition,
                                         player: player, map_segment: map_segment)
@@ -72,6 +82,14 @@ class CompositionSaver
       end
       Player.new(attrs)
     end
+  end
+
+  def init_composition_player(data, player:, composition:)
+    comp_player = CompositionPlayer.where(composition_id: composition,
+                                          player_id: player).
+                                    first_or_initialize
+    comp_player.position = data[:player_position] if data[:player_position]
+    comp_player
   end
 
   def init_composition(data, map:)

--- a/app/models/composition_saver.rb
+++ b/app/models/composition_saver.rb
@@ -78,7 +78,15 @@ class CompositionSaver
 
   def composition_for_authenticated_user(map:, id:)
     if id
-      Composition.where(id: id, user_id: @user).first
+      scope = Composition.where(id: id)
+      if @user
+        scope = scope.where(user_id: @user)
+      else
+        scope = scope.where(user_id: User.anonymous, session_id: @session_id)
+      end
+      comp = scope.first
+      comp.map = map
+      comp
     else
       Composition.new(map: map, user: @user)
     end

--- a/app/models/composition_saver.rb
+++ b/app/models/composition_saver.rb
@@ -1,0 +1,106 @@
+class CompositionSaver
+  attr_reader :error_type, :error_value, :composition
+
+  def initialize(user:, session_id:)
+    @user = user
+    @session_id = session_id
+  end
+
+  def save(data)
+    player = init_player(data)
+    unless player.persisted? || player.save
+      @error_type = 'player'
+      @error_value = player.errors
+      return
+    end
+
+    if data[:hero_id]
+      hero = Hero.find(data[:hero_id])
+      player_hero = init_player_hero(hero: hero, player: player)
+      unless player_hero.persisted? || player_hero.save
+        @error_type = 'player_hero'
+        @error_value = player_hero.errors
+        return
+      end
+    end
+
+    if data[:map_segment_id]
+      map_segment = MapSegment.find(data[:map_segment_id])
+      map = map_segment.map
+      @composition = init_composition(data, map: map)
+      unless @composition.persisted? || @composition.save
+        @error_type = 'composition'
+        @error_value = @composition.errors
+        return
+      end
+
+      player_selection = init_player_selection(composition: @composition,
+                                               player_hero: player_hero,
+                                               map_segment: map_segment)
+      unless player_selection.persisted? || player_selection.save
+        @error_type = 'player_selection'
+        @error_value = player_selection.errors
+        return
+      end
+    end
+
+    true
+  end
+
+  private
+
+  def init_player(data)
+    scope = Player.where(name: data[:player_name])
+    if @user
+      scope = scope.where(creator: @user)
+    else
+      scope = scope.where(creator: User.anonymous,
+                          creator_session_id: @session_id)
+    end
+    scope.first_or_initialize
+  end
+
+  def init_player_hero(hero:, player:)
+    return nil unless hero && player.persisted?
+
+    PlayerHero.where(player_id: player, hero_id: hero).first_or_initialize
+  end
+
+  def init_composition(data, map:)
+    id = data[:composition_id]
+
+    if @user
+      composition_for_authenticated_user(map: map, id: id)
+    else
+      composition_for_anonymous_user(map: map, id: id)
+    end
+  end
+
+  def composition_for_authenticated_user(map:, id:)
+    if id
+      Composition.where(id: id, user_id: @user).first
+    else
+      Composition.new(map: map, user: @user)
+    end
+  end
+
+  def composition_for_anonymous_user(map:, id:)
+    if id
+      Composition.where(id: id, user_id: User.anonymous,
+                        session_id: @session_id).first
+    else
+      Composition.new(map: map, session_id: @session_id,
+                      user: User.anonymous)
+    end
+  end
+
+  def init_player_selection(composition:, player_hero:, map_segment:)
+    if composition.persisted?
+      PlayerSelection.where(composition_id: composition,
+                            player_hero_id: player_hero,
+                            map_segment_id: map_segment).first_or_initialize
+    else
+      PlayerSelection.new(player_hero: player_hero, map_segment: map_segment)
+    end
+  end
+end

--- a/app/models/composition_saver.rb
+++ b/app/models/composition_saver.rb
@@ -19,21 +19,24 @@ class CompositionSaver
     if data[:map_segment_id]
       map_segment = MapSegment.find(data[:map_segment_id])
       map = map_segment.map
+    end
+
+    if data[:composition_id] || map
       @composition = init_composition(data, map: map)
       unless @composition.persisted? || @composition.save
         @error_type = 'composition'
         @error_value = @composition.errors
         return
       end
+    end
 
-      if player && data[:hero_id]
-        selection = init_player_selection(data, composition: @composition,
-                                          player: player, map_segment: map_segment)
-        unless selection.persisted? && !selection.changed? || selection.save
-          @error_type = 'player_selection'
-          @error_value = selection.errors
-          return
-        end
+    if player && map_segment && data[:hero_id]
+      selection = init_player_selection(data, composition: @composition,
+                                        player: player, map_segment: map_segment)
+      unless selection.persisted? && !selection.changed? || selection.save
+        @error_type = 'player_selection'
+        @error_value = selection.errors
+        return
       end
     end
 
@@ -85,7 +88,7 @@ class CompositionSaver
         scope = scope.where(user_id: User.anonymous, session_id: @session_id)
       end
       comp = scope.first
-      comp.map = map
+      comp.map = map if map
       comp
     else
       Composition.new(map: map, user: @user)

--- a/app/models/player_selection.rb
+++ b/app/models/player_selection.rb
@@ -8,6 +8,7 @@ class PlayerSelection < ApplicationRecord
   validates :player_id,
     uniqueness: { scope: [:composition_id, :map_segment_id] }
   validate :map_segment_matches_composition_map
+  validate :player_is_in_composition
 
   private
 
@@ -16,6 +17,14 @@ class PlayerSelection < ApplicationRecord
 
     unless map_segment.map == composition.map
       errors.add(:map_segment, 'must match the composition map.')
+    end
+  end
+
+  def player_is_in_composition
+    return unless player && composition
+
+    unless composition.players.include?(player)
+      errors.add(:player, 'is not part of the composition.')
     end
   end
 end

--- a/app/models/player_selection.rb
+++ b/app/models/player_selection.rb
@@ -1,10 +1,11 @@
 class PlayerSelection < ApplicationRecord
-  belongs_to :player_hero
+  belongs_to :player
+  belongs_to :hero
   belongs_to :composition
   belongs_to :map_segment
 
-  validates :player_hero, :composition, :map_segment, presence: true
-  validates :player_hero_id,
+  validates :player, :hero, :composition, :map_segment, presence: true
+  validates :player_id,
     uniqueness: { scope: [:composition_id, :map_segment_id] }
   validate :map_segment_matches_composition_map
 

--- a/app/views/compositions/last_composition.json.jbuilder
+++ b/app/views/compositions/last_composition.json.jbuilder
@@ -22,7 +22,7 @@ json.composition do
       json.id hero.id
       json.name hero.name
       json.confidence @hero_confidences[hero.id][player.name]
-      json.mapSegmentID @map_segment_ids[hero.id][player.name]
+      json.mapSegmentIDs @map_segment_ids[hero.id][player.name]
     end
   end
 end

--- a/app/views/compositions/save.json.jbuilder
+++ b/app/views/compositions/save.json.jbuilder
@@ -20,7 +20,7 @@ json.composition do
       json.id hero.id
       json.name hero.name
       json.confidence @hero_confidences[hero.id][player.name]
-      json.mapSegmentID @map_segment_ids[hero.id][player.name]
+      json.mapSegmentIDs @map_segment_ids[hero.id][player.name]
     end
   end
 end

--- a/db/migrate/20170311162208_split_player_hero_on_player_selections.rb
+++ b/db/migrate/20170311162208_split_player_hero_on_player_selections.rb
@@ -1,0 +1,24 @@
+class SplitPlayerHeroOnPlayerSelections < ActiveRecord::Migration[5.0]
+  def up
+    remove_column :player_selections, :player_hero_id
+
+    add_column :player_selections, :player_id, :integer, null: false
+    add_index :player_selections, :player_id
+
+    add_column :player_selections, :hero_id, :integer, null: false
+    add_index :player_selections, :hero_id
+
+    add_index :player_selections, [:map_segment_id, :composition_id, :player_id],
+      unique: true, name: 'idx_player_selections_unique_combo'
+  end
+
+  def down
+    remove_column :player_selections, :player_id
+    remove_column :player_selections, :hero_id
+
+    add_column :player_selections, :player_hero_id, :integer, null: false
+    add_index :player_selections, :player_hero_id
+    add_index :player_selections, [:map_segment_id, :composition_id, :player_hero_id],
+      unique: true, name: 'idx_player_selections_unique_combo'
+  end
+end

--- a/db/migrate/20170311171933_create_composition_players.rb
+++ b/db/migrate/20170311171933_create_composition_players.rb
@@ -1,0 +1,10 @@
+class CreateCompositionPlayers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :composition_players do |t|
+      t.references :composition, null: false
+      t.references :player, null: false
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170310233529) do
+ActiveRecord::Schema.define(version: 20170311162208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,15 +63,17 @@ ActiveRecord::Schema.define(version: 20170310233529) do
   end
 
   create_table "player_selections", force: :cascade do |t|
-    t.integer  "player_hero_id", null: false
     t.string   "role"
     t.integer  "composition_id", null: false
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
     t.integer  "map_segment_id", null: false
+    t.integer  "player_id",      null: false
+    t.integer  "hero_id",        null: false
     t.index ["composition_id"], name: "index_player_selections_on_composition_id", using: :btree
-    t.index ["map_segment_id", "composition_id", "player_hero_id"], name: "idx_player_selections_unique_combo", unique: true, using: :btree
-    t.index ["player_hero_id"], name: "index_player_selections_on_player_hero_id", using: :btree
+    t.index ["hero_id"], name: "index_player_selections_on_hero_id", using: :btree
+    t.index ["map_segment_id", "composition_id", "player_id"], name: "idx_player_selections_unique_combo", unique: true, using: :btree
+    t.index ["player_id"], name: "index_player_selections_on_player_id", using: :btree
   end
 
   create_table "players", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170311162208) do
+ActiveRecord::Schema.define(version: 20170311171933) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "composition_players", force: :cascade do |t|
+    t.integer  "composition_id",             null: false
+    t.integer  "player_id",                  null: false
+    t.integer  "position",       default: 0, null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.index ["composition_id"], name: "index_composition_players_on_composition_id", using: :btree
+    t.index ["player_id"], name: "index_composition_players_on_player_id", using: :btree
+  end
 
   create_table "compositions", force: :cascade do |t|
     t.string   "name",                               null: false

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "immutability-helper": "^2.1.2",
     "promise-polyfill": "^6.0.2",
     "react": "^15.4.2",
-    "throttle-debounce": "^1.0.1",
+    "react-debounce-input": "^2.4.2",
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {

--- a/spec/controllers/compositions_controller_spec.rb
+++ b/spec/controllers/compositions_controller_spec.rb
@@ -50,6 +50,27 @@ RSpec.describe CompositionsController do
       expect(response).to be_success, response.body
     end
 
+    it 'allows updating just a player name' do
+      sign_in @user
+      player = create(:player, name: 'oldName32', creator: @user)
+      composition = create(:composition, map: @map, user: @user)
+      selection = create(:player_selection, composition: composition,
+                         player: player, map_segment: @map_segment,
+                         hero: @hero1)
+
+      expect do
+        post :save, params: {
+          player_name: 'newName64', player_id: player.id, format: :json,
+          composition_id: composition.id
+        }
+      end.not_to change { Player.count }
+      expect(player.reload.name).to eq('newName64')
+      expect(composition.reload.map).to eq(@map)
+      expect(selection.reload.player).to eq(player)
+      expect(selection.map_segment).to eq(@map_segment)
+      expect(selection.hero).to eq(@hero1)
+    end
+
     it 'creates a new composition for authenticated user' do
       sign_in @user
 

--- a/spec/controllers/compositions_controller_spec.rb
+++ b/spec/controllers/compositions_controller_spec.rb
@@ -99,12 +99,15 @@ RSpec.describe CompositionsController do
 
       expect do
         post :save, params: {
-          player_name: 'newName64', format: :json, map_segment_id: @map_segment.id
+          player_name: 'newName64', format: :json, map_id: @map.id
         }
       end.to change { @user.created_players.count }.by(1)
-      expect(response).to be_success
-      expect(@user.compositions.last).not_to be_nil
-      expect(@user.compositions.last.players.pluck(:name)).to eq(['newName64'])
+      expect(response).to be_success, response.body
+
+      composition = @user.compositions.last
+      expect(composition).not_to be_nil
+      expect(composition.map).to eq(@map)
+      expect(composition.players.pluck(:name)).to eq(['newName64'])
     end
 
     it 'allows updating just a player name' do

--- a/spec/controllers/compositions_controller_spec.rb
+++ b/spec/controllers/compositions_controller_spec.rb
@@ -81,6 +81,19 @@ RSpec.describe CompositionsController do
       expect(response).to have_http_status(400)
     end
 
+    it 'allows creating just a player in the composition' do
+      sign_in @user
+      composition = create(:composition, map: @map, user: @user)
+
+      expect do
+        post :save, params: {
+          player_name: 'newName64', format: :json, composition_id: composition.id
+        }
+      end.to change { @user.created_players.count }.by(1)
+      expect(response).to be_success
+      expect(composition.players.pluck(:name)).to eq(['newName64'])
+    end
+
     it 'allows updating just a player name' do
       sign_in @user
       player = create(:player, name: 'oldName32', creator: @user)
@@ -95,6 +108,7 @@ RSpec.describe CompositionsController do
           composition_id: composition.id
         }
       end.not_to change { Player.count }
+      expect(response).to be_success
       expect(player.reload.name).to eq('newName64')
       expect(composition.reload.map).to eq(@map)
       expect(selection.reload.player).to eq(player)
@@ -111,6 +125,7 @@ RSpec.describe CompositionsController do
           map_segment_id: @map_segment.id, format: :json
         }
       end.to change { Composition.count }.by(1)
+      expect(response).to be_success
     end
 
     it 'creates a new composition for anonymous user' do
@@ -120,6 +135,7 @@ RSpec.describe CompositionsController do
           map_segment_id: @map_segment.id, format: :json
         }
       end.to change { @anon_user.compositions.count }.by(1)
+      expect(response).to be_success
     end
 
     it 'creates a new player for new name for authenticated user' do
@@ -131,6 +147,7 @@ RSpec.describe CompositionsController do
           map_segment_id: @map_segment.id, format: :json
         }
       end.to change { Player.count }.by(1)
+      expect(response).to be_success
       expect(@user.compositions.last.players.pluck(:name)).to eq(['chocotaco'])
     end
 
@@ -141,6 +158,7 @@ RSpec.describe CompositionsController do
           map_segment_id: @map_segment.id, format: :json
         }
       end.to change { @anon_user.created_players.count }.by(1)
+      expect(response).to be_success
       expect(@anon_user.compositions.last.players.pluck(:name)).to eq(['NiftyThrifty618'])
     end
 
@@ -154,6 +172,7 @@ RSpec.describe CompositionsController do
           map_segment_id: @map_segment.id, format: :json, player_id: player.id
         }
       end.not_to change { Player.count }
+      expect(response).to be_success
       expect(player.reload.name).to eq('gloriousNewPerson')
     end
 
@@ -166,6 +185,7 @@ RSpec.describe CompositionsController do
           map_segment_id: @map_segment.id, format: :json
         }
       end.to change { PlayerSelection.count }.by(1)
+      expect(response).to be_success
     end
 
     it 'no-op for existing player selection for authenticated user' do
@@ -184,6 +204,7 @@ RSpec.describe CompositionsController do
           player_id: player.id
         }
       end.not_to change { PlayerSelection.count }
+      expect(response).to be_success
       expect(player_selection.reload.hero).to eq(@hero2)
     end
   end

--- a/spec/controllers/compositions_controller_spec.rb
+++ b/spec/controllers/compositions_controller_spec.rb
@@ -65,6 +65,22 @@ RSpec.describe CompositionsController do
       expect(response).to have_http_status(400)
     end
 
+    it "does not allow updating another user's composition" do
+      sign_in @user
+      composition = create(:composition, map: @map)
+      new_map = create(:map, name: 'Oasis')
+      map_segment = create(:map_segment, map: new_map)
+
+      expect do
+        post :save, params: {
+          format: :json, composition_id: composition.id,
+          map_segment_id: map_segment.id
+        }
+      end.not_to change { Composition.count }
+      expect(composition.reload.map).to eq(@map)
+      expect(response).to have_http_status(400)
+    end
+
     it 'allows updating just a player name' do
       sign_in @user
       player = create(:player, name: 'oldName32', creator: @user)

--- a/spec/controllers/compositions_controller_spec.rb
+++ b/spec/controllers/compositions_controller_spec.rb
@@ -94,6 +94,19 @@ RSpec.describe CompositionsController do
       expect(composition.players.pluck(:name)).to eq(['newName64'])
     end
 
+    it 'allows creating a player in a new composition' do
+      sign_in @user
+
+      expect do
+        post :save, params: {
+          player_name: 'newName64', format: :json, map_segment_id: @map_segment.id
+        }
+      end.to change { @user.created_players.count }.by(1)
+      expect(response).to be_success
+      expect(@user.compositions.last).not_to be_nil
+      expect(@user.compositions.last.players.pluck(:name)).to eq(['newName64'])
+    end
+
     it 'allows updating just a player name' do
       sign_in @user
       player = create(:player, name: 'oldName32', creator: @user)

--- a/spec/controllers/compositions_controller_spec.rb
+++ b/spec/controllers/compositions_controller_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe CompositionsController do
           map_segment_id: @map_segment.id, format: :json
         }
       end.to change { Player.count }.by(1)
+      expect(@user.compositions.last.players.pluck(:name)).to eq(['chocotaco'])
     end
 
     it 'creates a new player for new name for anonymous user' do
@@ -140,6 +141,7 @@ RSpec.describe CompositionsController do
           map_segment_id: @map_segment.id, format: :json
         }
       end.to change { @anon_user.created_players.count }.by(1)
+      expect(@anon_user.compositions.last.players.pluck(:name)).to eq(['NiftyThrifty618'])
     end
 
     it 'reuses existing player for authenticated user' do

--- a/spec/controllers/compositions_controller_spec.rb
+++ b/spec/controllers/compositions_controller_spec.rb
@@ -96,10 +96,11 @@ RSpec.describe CompositionsController do
 
       expect do
         post :save, params: {
-          player_name: player.name, hero_id: @hero1.id,
-          map_segment_id: @map_segment.id, format: :json
+          player_name: 'gloriousNewPerson', hero_id: @hero1.id,
+          map_segment_id: @map_segment.id, format: :json, player_id: player.id
         }
       end.not_to change { Player.count }
+      expect(player.reload.name).to eq('gloriousNewPerson')
     end
 
     it 'creates a new player-hero for new combination for auth user' do
@@ -121,7 +122,7 @@ RSpec.describe CompositionsController do
       expect do
         post :save, params: {
           player_name: player.name, hero_id: @hero1.id,
-          map_segment_id: @map_segment.id, format: :json
+          map_segment_id: @map_segment.id, format: :json, player_id: player.id
         }
       end.not_to change { PlayerHero.count }
     end
@@ -150,7 +151,8 @@ RSpec.describe CompositionsController do
       expect do
         post :save, params: {
           player_name: player.name, hero_id: @hero1.id, format: :json,
-          composition_id: composition.id, map_segment_id: @map_segment.id
+          composition_id: composition.id, map_segment_id: @map_segment.id,
+          player_id: player.id
         }
       end.not_to change { PlayerSelection.count }
     end

--- a/spec/controllers/compositions_controller_spec.rb
+++ b/spec/controllers/compositions_controller_spec.rb
@@ -103,30 +103,6 @@ RSpec.describe CompositionsController do
       expect(player.reload.name).to eq('gloriousNewPerson')
     end
 
-    it 'creates a new player-hero for new combination for auth user' do
-      sign_in @user
-
-      expect do
-        post :save, params: {
-          player_name: 'chocotaco', hero_id: @hero1.id,
-          map_segment_id: @map_segment.id, format: :json
-        }
-      end.to change { PlayerHero.count }.by(1)
-    end
-
-    it 'reuses an existing player-hero combination for auth user' do
-      sign_in @user
-      player = create(:player, creator: @user)
-      player_hero = create(:player_hero, player: player, hero: @hero1)
-
-      expect do
-        post :save, params: {
-          player_name: player.name, hero_id: @hero1.id,
-          map_segment_id: @map_segment.id, format: :json, player_id: player.id
-        }
-      end.not_to change { PlayerHero.count }
-    end
-
     it 'creates a new player selection for authenticated user' do
       sign_in @user
 
@@ -142,19 +118,19 @@ RSpec.describe CompositionsController do
       sign_in @user
 
       player = create(:player, creator: @user)
-      player_hero = create(:player_hero, player: player, hero: @hero1)
       composition = create(:composition, user: @user, map: @map)
       player_selection = create(:player_selection, composition: composition,
-                                player_hero: player_hero,
+                                player: player, hero: @hero1,
                                 map_segment: @map_segment)
 
       expect do
         post :save, params: {
-          player_name: player.name, hero_id: @hero1.id, format: :json,
+          player_name: player.name, hero_id: @hero2.id, format: :json,
           composition_id: composition.id, map_segment_id: @map_segment.id,
           player_id: player.id
         }
       end.not_to change { PlayerSelection.count }
+      expect(player_selection.reload.hero).to eq(@hero2)
     end
   end
 end

--- a/spec/controllers/compositions_controller_spec.rb
+++ b/spec/controllers/compositions_controller_spec.rb
@@ -50,6 +50,21 @@ RSpec.describe CompositionsController do
       expect(response).to be_success, response.body
     end
 
+    it "does not allow updating another user's player" do
+      sign_in @user
+      player = create(:player, name: 'oldName32')
+      composition = create(:composition, map: @map, user: @user)
+
+      expect do
+        post :save, params: {
+          player_name: 'newName64', player_id: player.id, format: :json,
+          composition_id: composition.id
+        }
+      end.not_to change { Player.count }
+      expect(player.reload.name).to eq('oldName32')
+      expect(response).to have_http_status(400)
+    end
+
     it 'allows updating just a player name' do
       sign_in @user
       player = create(:player, name: 'oldName32', creator: @user)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -30,7 +30,7 @@ FactoryGirl.define do
   end
 
   factory :player do
-    name 'zion'
+    name { "zion#{Player.count}" }
     association :creator, factory: :user
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -36,7 +36,8 @@ FactoryGirl.define do
   end
 
   factory :player_selection do
-    player_hero
+    player
+    hero
     composition
     map_segment { create(:map_segment, map: composition.map) }
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -9,6 +9,11 @@ FactoryGirl.define do
     user
   end
 
+  factory :composition_player do
+    composition
+    player
+  end
+
   factory :hero do
     name 'McCree'
     role 'offense'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -45,6 +45,11 @@ FactoryGirl.define do
     hero
     composition
     map_segment { create(:map_segment, map: composition.map) }
+
+    before(:create) do |player_selection, evaluator|
+      create(:composition_player, composition: player_selection.composition,
+             player: player_selection.player)
+    end
   end
 
   factory :user do

--- a/spec/models/composition_player_spec.rb
+++ b/spec/models/composition_player_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe CompositionPlayer, type: :model do
+  it 'requires a composition' do
+    comp_player = CompositionPlayer.new
+    expect(comp_player.valid?).to be_falsey
+    expect(comp_player.errors[:composition].any?).to be_truthy
+  end
+
+  it 'requires a player' do
+    comp_player = CompositionPlayer.new
+    expect(comp_player.valid?).to be_falsey
+    expect(comp_player.errors[:player].any?).to be_truthy
+  end
+
+  it 'sets position' do
+    comp_player = create(:composition_player, position: nil)
+    expect(comp_player.position).to eq(0)
+
+    comp_player2 = create(:composition_player, position: nil,
+                          composition: comp_player.composition,
+                          player: comp_player.player)
+    expect(comp_player2.position).to eq(1)
+  end
+end

--- a/spec/models/composition_player_spec.rb
+++ b/spec/models/composition_player_spec.rb
@@ -22,4 +22,12 @@ RSpec.describe CompositionPlayer, type: :model do
                           player: comp_player.player)
     expect(comp_player2.position).to eq(1)
   end
+
+  it 'disallows more than 6 players per composition' do
+    composition = create(:composition)
+    6.times { create(:composition_player, composition: composition) }
+    seventh = build(:composition_player, composition: composition)
+    expect(seventh.valid?).to be_falsey
+    expect(seventh.errors[:composition].any?).to be_truthy
+  end
 end

--- a/spec/models/player_selection_spec.rb
+++ b/spec/models/player_selection_spec.rb
@@ -1,10 +1,16 @@
 require 'rails_helper'
 
 describe PlayerSelection do
-  it "requires a player-hero" do
+  it 'requires a player' do
     ps = PlayerSelection.new
     expect(ps.valid?).to be_falsey
-    expect(ps.errors[:player_hero].any?).to be_truthy
+    expect(ps.errors[:player].any?).to be_truthy
+  end
+
+  it 'requires a hero' do
+    ps = PlayerSelection.new
+    expect(ps.valid?).to be_falsey
+    expect(ps.errors[:hero].any?).to be_truthy
   end
 
   it "requires a composition" do
@@ -19,12 +25,14 @@ describe PlayerSelection do
     expect(ps.errors[:map_segment].any?).to be_truthy
   end
 
-  it 'requires a unique map segment + composition + player-hero combo' do
+  it 'requires a unique map segment + composition + player combo' do
     existing = create(:player_selection)
+    new_hero = create(:hero, name: 'Orisa')
     ps = PlayerSelection.new(map_segment: existing.map_segment,
                              composition: existing.composition,
-                             player_hero: existing.player_hero)
+                             player: existing.player,
+                             hero: new_hero)
     expect(ps.valid?).to be_falsey
-    expect(ps.errors[:player_hero_id].any?).to be_truthy
+    expect(ps.errors[:player_id].any?).to be_truthy
   end
 end

--- a/spec/models/player_selection_spec.rb
+++ b/spec/models/player_selection_spec.rb
@@ -19,6 +19,18 @@ describe PlayerSelection do
     expect(ps.errors[:composition].any?).to be_truthy
   end
 
+  it 'requires player belong to composition' do
+    player = create(:player)
+    hero = create(:hero)
+    map = create(:map)
+    comp = create(:composition, map: map)
+    map_segment = create(:map_segment, map: map)
+    ps = PlayerSelection.new(player: player, composition: comp,
+                             hero: hero, map_segment: map_segment)
+    expect(ps.valid?).to be_falsey
+    expect(ps.errors[:player].any?).to be_truthy
+  end
+
   it 'requires a map segment' do
     ps = PlayerSelection.new
     expect(ps.valid?).to be_falsey

--- a/spec/requests/compositions_api_spec.rb
+++ b/spec/requests/compositions_api_spec.rb
@@ -91,11 +91,11 @@ RSpec.describe 'compositions API' do
       expect(player_json['heroes'].length).to eq(2)
 
       selected_json = player_json['heroes'].detect do |sj|
-        sj['mapSegmentID'] != nil
+        sj['mapSegmentIDs'] != nil
       end
       expect(selected_json).not_to be_nil
       expect(selected_json['name']).to eq(@hero1.name)
-      expect(selected_json['mapSegmentID']).to eq(@map_segment.id)
+      expect(selected_json['mapSegmentIDs']).to eq([@map_segment.id])
     end
   end
 

--- a/spec/requests/compositions_api_spec.rb
+++ b/spec/requests/compositions_api_spec.rb
@@ -40,53 +40,12 @@ RSpec.describe 'compositions API' do
 
       post '/api/compositions', params: {
         player_name: player.name, hero_id: @hero1.id,
-        map_segment_id: @map_segment.id
+        map_segment_id: @map_segment.id, player_id: player.id
       }
 
       json = JSON.parse(response.body)
       expect(json).to have_key('composition')
       expect(json['composition']['players'][0]['name']).to eq(player.name)
-    end
-
-    it 'returns new player-hero info for new combination for auth user' do
-      sign_in @user
-      post '/api/compositions', params: {
-        player_name: 'chocotaco', hero_id: @hero1.id,
-        map_segment_id: @map_segment.id
-      }
-
-      json = JSON.parse(response.body)
-      expect(json).to have_key('composition')
-      expect(json['composition']['players'][0]['name']).to eq('chocotaco')
-
-      expect(json['composition']['players'][0]['heroes'][0]['name']).to eq(@hero1.name)
-    end
-
-    it 'returns existing player-hero combination for auth user' do
-      sign_in @user
-      player = create(:player, creator: @user)
-      player_hero = create(:player_hero, player: player, hero: @hero1)
-
-      post '/api/compositions', params: {
-        player_name: player.name, hero_id: @hero1.id,
-        map_segment_id: @map_segment.id
-      }
-
-      json = JSON.parse(response.body)
-      expect(json).to have_key('composition')
-
-      player_json = json['composition']['players'].detect do |pj|
-        pj['name'] == player.name
-      end
-      expect(player_json).not_to be_nil
-      expect(player_json['heroes'].length).to eq(2)
-
-      selected_json = player_json['heroes'].detect do |sj|
-        sj['mapSegmentID'] != nil
-      end
-      expect(selected_json).not_to be_nil
-      expect(selected_json['name']).to eq(@hero1.name)
-      expect(selected_json['mapSegmentID']).to eq(@map_segment.id)
     end
 
     it 'returns new player selection for authenticated user' do
@@ -110,19 +69,19 @@ RSpec.describe 'compositions API' do
       sign_in @user
 
       player = create(:player, creator: @user)
-      player_hero = create(:player_hero, player: player, hero: @hero1)
       composition = create(:composition, user: @user, map: @map)
       player_selection = create(:player_selection, composition: composition,
-                                player_hero: player_hero,
+                                player: player, hero: @hero1,
                                 map_segment: @map_segment)
 
       post '/api/compositions', params: {
         player_name: player.name, hero_id: @hero1.id,
-        composition_id: composition.id, map_segment_id: @map_segment.id
+        composition_id: composition.id, map_segment_id: @map_segment.id,
+        player_id: player.id
       }
 
       json = JSON.parse(response.body)
-      expect(json).to have_key('composition')
+      expect(json).to have_key('composition'), response.body
       expect(json['composition']['players'][0]['name']).to eq(player.name)
 
       player_json = json['composition']['players'].detect do |pj|


### PR DESCRIPTION
Fixes #51.

I discovered a problem with our logic for storing a `player_hero_id` on `player_selections`: it doesn't let us update the hero selection for a given player in a composition at a particular map segment. So I split the key into `player_id` and `hero_id` and put a unique index on `map_segment_id` + `composition_id` + `player_id` so we disallow having the same player on multiple heroes for the same point in a given composition. Discussed with @rewinfrey to confirm my thinking.

Another gap in our data model was we didn't allow for the team organizer to set a player name without first having made a hero selection for that player. So I could enter all my players' names and reload the page, and none of them would be persisted. I added a `composition_players` table to tie players in a particular order to the composition.

This replaces the throttle-debounce npm package with [react-debounce-input](https://github.com/nkbt/react-debounce-input) since it's built to work with React and I was able to get it working with the normal `value` and `onChange` properties you should use on an `input`.

This also refactors CompositionsController#save so it makes use of a new CompositionSaver model. This pulls a lot of logic out of the controller and makes things easier to read.

Here's the new functionality; note the page reload in the middle and how the data fills back in:

![saving-overwatch-team-comp-loop](https://cloud.githubusercontent.com/assets/82317/23825945/e65d015a-0658-11e7-8386-d61c88775dde.gif)
