### PR TITLE
Update compositions and players on user signup

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -20,10 +20,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
                     password: Devise.friendly_token[0,20])
 
     if user.save
-      Player.where(creator_id: User.anonymous, creator_session_id: session.id).
-             update_all(creator_id: user.id)
-      Composition.where(user_id: User.anonymous, session_id: session.id).
-                  update_all(user_id: user.id)
+      user.migrate_session_records(session.id)
 
       session['devise.bnet_data'] = nil
       set_flash_message(:notice, :success, kind: "Battle.net")

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -20,6 +20,11 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
                     password: Devise.friendly_token[0,20])
 
     if user.save
+      Player.where(creator_id: User.anonymous, creator_session_id: session.id).
+             update_all(user_id: user.id)
+      Composition.where(user_id: User.anonymous, session_id: session.id).
+                  update_all(user_id: user.id)
+
       session['devise.bnet_data'] = nil
       set_flash_message(:notice, :success, kind: "Battle.net")
       sign_in_and_redirect user, event: :authentication

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -13,10 +13,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def finished_signup
-    auth = session['devise.bnet_data']
-    user = User.new(provider: auth['provider'], uid: auth['uid'],
+    @auth = session['devise.bnet_data']
+    user = User.new(provider: @auth['provider'], uid: @auth['uid'],
                     email: params[:email],
-                    battletag: auth['info']['battletag'],
+                    battletag: @auth['info']['battletag'],
                     password: Devise.friendly_token[0,20])
 
     if user.save
@@ -24,7 +24,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       set_flash_message(:notice, :success, kind: "Battle.net")
       sign_in_and_redirect user, event: :authentication
     else
-      redirect_to new_user_registration_url
+      flash[:alert] = 'Please provide an email address.'
+      render :finish_signup
     end
   end
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -21,7 +21,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     if user.save
       Player.where(creator_id: User.anonymous, creator_session_id: session.id).
-             update_all(user_id: user.id)
+             update_all(creator_id: user.id)
       Composition.where(user_id: User.anonymous, session_id: session.id).
                   update_all(user_id: user.id)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,4 +21,11 @@ class User < ApplicationRecord
   def anonymous?
     email == ANONYMOUS_EMAIL
   end
+
+  def migrate_session_records(session_id)
+    Player.where(creator_id: self.class.anonymous,
+                 creator_session_id: session_id).update_all(creator_id: id)
+    Composition.where(user_id: self.class.anonymous,
+                      session_id: session_id).update_all(user_id: id)
+  end
 end

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Users::OmniauthCallbacksController do
-  render_views
-
   before(:each) do
     OmniAuth.config.test_mode = true
 
@@ -32,10 +30,41 @@ RSpec.describe Users::OmniauthCallbacksController do
   end
 
   describe 'GET finish_signup' do
+    render_views
+
     it 'loads successfully' do
       get :finish_signup, session: { 'devise.bnet_data' => OmniAuth.config.mock_auth[:bnet] }
       expect(response).to be_success
       expect(response.body).to include('coollady#1965')
+    end
+  end
+
+  describe 'POST finished_signup' do
+    render_views
+
+    it 'creates a user' do
+      expect do
+        post :finished_signup, params: { email: 'test@example.com' },
+          session: { 'devise.bnet_data' => OmniAuth.config.mock_auth[:bnet] }
+      end.to change { User.count }.by(1)
+      expect(response).to redirect_to('/')
+      expect(flash[:notice]).to eq('Successfully authenticated from Battle.net account.')
+
+      user = User.last
+      expect(user.email).to eq('test@example.com')
+      expect(user.provider).to eq('bnet')
+      expect(user.uid).to eq('123456')
+      expect(user.battletag).to eq('coollady#1965')
+    end
+
+    it 'does not save user when email is omitted' do
+      expect do
+        post :finished_signup, params: { email: '' },
+          session: { 'devise.bnet_data' => OmniAuth.config.mock_auth[:bnet] }
+      end.not_to change { User.count }
+      expect(response).to be_success
+      expect(response.body).to include('coollady#1965')
+      expect(response.body).to include('Please provide an email address.')
     end
   end
 end

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Users::OmniauthCallbacksController do
+  before(:each) do
+    OmniAuth.config.test_mode = true
+
+    OmniAuth.config.mock_auth[:bnet] = OmniAuth::AuthHash.new(
+      provider: 'bnet',
+      uid: '123456'
+    )
+
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+    @request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:bnet]
+  end
+
+  describe 'POST bnet' do
+    it 'continues sign-up flow for new user' do
+      expect { post :bnet }.not_to change { User.count }
+      expect(session['devise.bnet_data']).not_to be_nil
+      expect(response).to redirect_to('/users/finish_signup')
+    end
+
+    it 'redirects to home for existing user' do
+      user = create(:user, provider: 'bnet', uid: '123456')
+      expect { post :bnet }.not_to change { User.count }
+      expect(session['devise.bnet_data']).to be_nil
+      expect(response).to redirect_to('/')
+    end
+  end
+end

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -1,12 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Users::OmniauthCallbacksController do
+  render_views
+
   before(:each) do
     OmniAuth.config.test_mode = true
 
     OmniAuth.config.mock_auth[:bnet] = OmniAuth::AuthHash.new(
       provider: 'bnet',
-      uid: '123456'
+      uid: '123456',
+      info: { battletag: 'coollady#1965' }
     )
 
     @request.env['devise.mapping'] = Devise.mappings[:user]
@@ -16,7 +19,7 @@ RSpec.describe Users::OmniauthCallbacksController do
   describe 'POST bnet' do
     it 'continues sign-up flow for new user' do
       expect { post :bnet }.not_to change { User.count }
-      expect(session['devise.bnet_data']).not_to be_nil
+      expect(session['devise.bnet_data']).to eq(OmniAuth.config.mock_auth[:bnet])
       expect(response).to redirect_to('/users/finish_signup')
     end
 
@@ -25,6 +28,14 @@ RSpec.describe Users::OmniauthCallbacksController do
       expect { post :bnet }.not_to change { User.count }
       expect(session['devise.bnet_data']).to be_nil
       expect(response).to redirect_to('/')
+    end
+  end
+
+  describe 'GET finish_signup' do
+    it 'loads successfully' do
+      get :finish_signup, session: { 'devise.bnet_data' => OmniAuth.config.mock_auth[:bnet] }
+      expect(response).to be_success
+      expect(response.body).to include('coollady#1965')
     end
   end
 end


### PR DESCRIPTION
Fixes #58 by tying existing Player and Composition records to the newly created User on user signup, based on the session ID.

This also fixes a bug where if you didn't provide an email address when signing up, you'd get a 500 error instead of a gentle nudge to enter an email address.

This also gives us better test coverage (read: any at all) for the Users::OmniauthCallbacksController class.