### PR TITLE
User composition_player_id on player_selections

### DIFF
--- a/app/models/composition_player.rb
+++ b/app/models/composition_player.rb
@@ -2,11 +2,16 @@ class CompositionPlayer < ApplicationRecord
   belongs_to :composition
   belongs_to :player
 
+  has_many :player_selections, dependent: :destroy
+
   before_validation :set_position
 
   validates :player, :composition, :position, presence: true
-  validates :position, numericality: { only_integer: true }
+  validates :position, numericality: { only_integer: true },
+    inclusion: 0...Composition::MAX_PLAYERS
+  validates :player_id, uniqueness: { scope: :composition_id }
   validate :composition_does_not_have_max_players
+  validate :player_is_allowed_for_comp_owner
 
   default_scope { order(:position) }
 
@@ -26,6 +31,21 @@ class CompositionPlayer < ApplicationRecord
 
     if scope.count > Composition::MAX_PLAYERS - 1
       errors.add(:composition, 'has maximum number of players already.')
+    end
+  end
+
+  def player_is_allowed_for_comp_owner
+    return unless player && composition
+
+    if player.creator.anonymous?
+      unless composition.user.anonymous? &&
+             composition.session_id == player.creator_session_id
+        errors.add(:player, 'is not valid.')
+      end
+    else
+      unless composition.user == player.creator
+        errors.add(:player, 'is not valid.')
+      end
     end
   end
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -16,10 +16,9 @@ class Player < ApplicationRecord
   # Returns Player or nil.
   def self.find_if_allowed(id, user:, session_id:)
     scope = if user
-      where('id = ? AND creator_id = ?', id, user)
+      where(id: id, creator_id: user)
     else
-      where('id = ? AND creator_id = ? AND creator_session_id = ?',
-            id, User.anonymous, session_id)
+      where(id: id, creator_id: User.anonymous, creator_session_id: session_id)
     end
 
     scope.first

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -8,6 +8,23 @@ class Player < ApplicationRecord
   validate :creator_session_id_set_if_anonymous
   validate :name_is_unique_to_creator
 
+  scope :order_by_name, ->{ order('UPPER(name) ASC') }
+
+  # Returns the Player with the given ID, but only if that Player is
+  # owned by the given User/session.
+  #
+  # Returns Player or nil.
+  def self.find_if_allowed(id, user:, session_id:)
+    scope = if user
+      where('id = ? AND creator_id = ?', id, user)
+    else
+      where('id = ? AND creator_id = ? AND creator_session_id = ?',
+            id, User.anonymous, session_id)
+    end
+
+    scope.first
+  end
+
   # Given a list of names for players already in a composition, this will
   # return a reasonable default name for a new player.
   def self.get_name(existing_names)

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -6,6 +6,7 @@ class Player < ApplicationRecord
 
   validates :name, :creator, presence: true
   validate :creator_session_id_set_if_anonymous
+  validate :name_is_unique_to_creator
 
   # Given a list of names for players already in a composition, this will
   # return a reasonable default name for a new player.
@@ -39,5 +40,21 @@ class Player < ApplicationRecord
     return if creator_session_id.present?
 
     errors.add(:creator_session_id, 'is required if creator is anonymous user.')
+  end
+
+  def name_is_unique_to_creator
+    return unless name && creator
+
+    scope = self.class.where(name: name, creator_id: creator)
+
+    if creator.anonymous?
+      scope = scope.where(creator_session_id: creator_session_id)
+    end
+
+    scope = scope.where('id <> ?', id) if persisted?
+
+    if scope.count > 0
+      errors.add(:name, 'has already been taken.')
+    end
   end
 end

--- a/app/models/player_selection.rb
+++ b/app/models/player_selection.rb
@@ -1,30 +1,23 @@
 class PlayerSelection < ApplicationRecord
-  belongs_to :player
+  belongs_to :composition_player
   belongs_to :hero
-  belongs_to :composition
   belongs_to :map_segment
 
-  validates :player, :hero, :composition, :map_segment, presence: true
-  validates :player_id,
-    uniqueness: { scope: [:composition_id, :map_segment_id] }
+  has_one :composition, through: :composition_player
+  has_one :player, through: :composition_player
+  has_one :map, through: :map_segment
+
+  validates :composition_player, :hero, :map_segment, presence: true
+  validates :composition_player_id, uniqueness: { scope: :map_segment_id }
   validate :map_segment_matches_composition_map
-  validate :player_is_in_composition
 
   private
 
   def map_segment_matches_composition_map
-    return unless map_segment && composition
+    return unless map && composition
 
-    unless map_segment.map == composition.map
+    unless map == composition.map
       errors.add(:map_segment, 'must match the composition map.')
-    end
-  end
-
-  def player_is_in_composition
-    return unless player && composition
-
-    unless composition.players.include?(player)
-      errors.add(:player, 'is not part of the composition.')
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
 
   ANONYMOUS_EMAIL = 'anonymous@overwatch-team-comps.com'.freeze
 
+  alias_attribute :to_s, :email
+
   # Returns the special User for representing anonymous site visitors.
   def self.anonymous
     find_by_email ANONYMOUS_EMAIL

--- a/db/migrate/20170312164116_add_unique_composition_players_index.rb
+++ b/db/migrate/20170312164116_add_unique_composition_players_index.rb
@@ -1,0 +1,11 @@
+class AddUniqueCompositionPlayersIndex < ActiveRecord::Migration[5.0]
+  def up
+    add_index :composition_players, [:composition_id, :player_id], unique: true
+    remove_index :composition_players, :composition_id
+  end
+
+  def down
+    add_index :composition_players, :composition_id
+    remove_index :composition_players, [:composition_id, :player_id]
+  end
+end

--- a/db/migrate/20170312174742_add_comp_player_to_player_selection.rb
+++ b/db/migrate/20170312174742_add_comp_player_to_player_selection.rb
@@ -1,0 +1,24 @@
+class AddCompPlayerToPlayerSelection < ActiveRecord::Migration[5.0]
+  def up
+    remove_column :player_selections, :composition_id
+    remove_column :player_selections, :player_id
+
+    add_column :player_selections, :composition_player_id, :integer, null: false
+    add_index :player_selections, :composition_player_id
+    add_index :player_selections, [:composition_player_id, :map_segment_id],
+      unique: true, name: 'idx_player_selections_unique_combo'
+  end
+
+  def down
+    remove_column :player_selections, :composition_player_id
+
+    add_column :player_selections, :composition_id, :integer, null: false
+    add_index :player_selections, :composition_id
+
+    add_column :player_selections, :player_id, :integer, null: false
+    add_index :player_selections, :player_id
+
+    add_index :player_selections, [:map_segment_id, :composition_id, :player_id],
+      unique: true, name: 'idx_player_selections_unique_combo'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170311171933) do
+ActiveRecord::Schema.define(version: 20170312174742) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20170311171933) do
     t.integer  "position",       default: 0, null: false
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
-    t.index ["composition_id"], name: "index_composition_players_on_composition_id", using: :btree
+    t.index ["composition_id", "player_id"], name: "index_composition_players_on_composition_id_and_player_id", unique: true, using: :btree
     t.index ["player_id"], name: "index_composition_players_on_player_id", using: :btree
   end
 
@@ -74,16 +74,14 @@ ActiveRecord::Schema.define(version: 20170311171933) do
 
   create_table "player_selections", force: :cascade do |t|
     t.string   "role"
-    t.integer  "composition_id", null: false
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
-    t.integer  "map_segment_id", null: false
-    t.integer  "player_id",      null: false
-    t.integer  "hero_id",        null: false
-    t.index ["composition_id"], name: "index_player_selections_on_composition_id", using: :btree
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
+    t.integer  "map_segment_id",        null: false
+    t.integer  "hero_id",               null: false
+    t.integer  "composition_player_id", null: false
+    t.index ["composition_player_id", "map_segment_id"], name: "idx_player_selections_unique_combo", unique: true, using: :btree
+    t.index ["composition_player_id"], name: "index_player_selections_on_composition_player_id", using: :btree
     t.index ["hero_id"], name: "index_player_selections_on_hero_id", using: :btree
-    t.index ["map_segment_id", "composition_id", "player_id"], name: "idx_player_selections_unique_combo", unique: true, using: :btree
-    t.index ["player_id"], name: "index_player_selections_on_player_id", using: :btree
   end
 
   create_table "players", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :anonymous_user, class: User do
-    email "anonymous@overwatch-team-comps.com"
+    email { User::ANONYMOUS_EMAIL }
     password "passworD1"
   end
 
@@ -11,7 +11,7 @@ FactoryGirl.define do
 
   factory :composition_player do
     composition
-    player
+    player { create(:player, creator: composition.user) }
   end
 
   factory :hero do
@@ -20,13 +20,13 @@ FactoryGirl.define do
   end
 
   factory :map do
-    name 'Dorado'
+    name { "Dorado #{Map.count}" }
     map_type 'escort'
   end
 
   factory :map_segment do
     map
-    name 'Attacking: Payload 1'
+    name { "Attacking: Payload #{MapSegment.count}" }
   end
 
   factory :player do
@@ -41,15 +41,9 @@ FactoryGirl.define do
   end
 
   factory :player_selection do
-    player
     hero
-    composition
-    map_segment { create(:map_segment, map: composition.map) }
-
-    before(:create) do |player_selection, evaluator|
-      create(:composition_player, composition: player_selection.composition,
-             player: player_selection.player)
-    end
+    composition_player
+    map_segment { create(:map_segment, map: composition_player.composition.map) }
   end
 
   factory :user do

--- a/spec/models/composition_player_spec.rb
+++ b/spec/models/composition_player_spec.rb
@@ -18,9 +18,20 @@ RSpec.describe CompositionPlayer, type: :model do
     expect(comp_player.position).to eq(0)
 
     comp_player2 = create(:composition_player, position: nil,
-                          composition: comp_player.composition,
-                          player: comp_player.player)
+                          composition: comp_player.composition)
     expect(comp_player2.position).to eq(1)
+  end
+
+  it 'disallows position less than 0' do
+    comp_player = build(:composition_player, position: -1)
+    expect(comp_player.valid?).to be_falsey
+    expect(comp_player.errors[:position].any?).to be_truthy
+  end
+
+  it 'disallows position greater than 5' do
+    comp_player = build(:composition_player, position: 6)
+    expect(comp_player.valid?).to be_falsey
+    expect(comp_player.errors[:position].any?).to be_truthy
   end
 
   it 'disallows more than 6 players per composition' do
@@ -29,5 +40,26 @@ RSpec.describe CompositionPlayer, type: :model do
     seventh = build(:composition_player, composition: composition)
     expect(seventh.valid?).to be_falsey
     expect(seventh.errors[:composition].any?).to be_truthy
+  end
+
+  it 'requires a unique player per composition' do
+    owner = create(:user)
+    composition = create(:composition, user: owner)
+    player = create(:player, creator: owner)
+    create(:composition_player, composition: composition,
+           player: player)
+    comp_player = build(:composition_player, composition: composition,
+                        player: player)
+    expect(comp_player.valid?).to be_falsey
+    expect(comp_player.errors[:player_id].any?).to be_truthy
+  end
+
+  it 'requires same owner for composition and player' do
+    composition = create(:composition)
+    player = create(:player)
+    comp_player = build(:composition_player, composition: composition,
+                        player: player)
+    expect(comp_player.valid?).to be_falsey
+    expect(comp_player.errors[:player].any?).to be_truthy
   end
 end

--- a/spec/models/player_selection_spec.rb
+++ b/spec/models/player_selection_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 describe PlayerSelection do
-  it 'requires a player' do
+  it 'requires a composition-player' do
     ps = PlayerSelection.new
     expect(ps.valid?).to be_falsey
-    expect(ps.errors[:player].any?).to be_truthy
+    expect(ps.errors[:composition_player].any?).to be_truthy
   end
 
   it 'requires a hero' do
@@ -13,38 +13,28 @@ describe PlayerSelection do
     expect(ps.errors[:hero].any?).to be_truthy
   end
 
-  it "requires a composition" do
-    ps = PlayerSelection.new
-    expect(ps.valid?).to be_falsey
-    expect(ps.errors[:composition].any?).to be_truthy
-  end
-
-  it 'requires player belong to composition' do
-    player = create(:player)
-    hero = create(:hero)
-    map = create(:map)
-    comp = create(:composition, map: map)
-    map_segment = create(:map_segment, map: map)
-    ps = PlayerSelection.new(player: player, composition: comp,
-                             hero: hero, map_segment: map_segment)
-    expect(ps.valid?).to be_falsey
-    expect(ps.errors[:player].any?).to be_truthy
-  end
-
   it 'requires a map segment' do
     ps = PlayerSelection.new
     expect(ps.valid?).to be_falsey
     expect(ps.errors[:map_segment].any?).to be_truthy
   end
 
-  it 'requires a unique map segment + composition + player combo' do
+  it 'requires the map segment be part of the composition map' do
+    composition = create(:composition)
+    map_segment = create(:map_segment)
+    ps = PlayerSelection.new(map_segment: map_segment,
+                             composition: composition)
+    expect(ps.valid?).to be_falsey
+    expect(ps.errors[:map_segment].any?).to be_truthy
+  end
+
+  it 'requires a unique map segment + composition-player combo' do
     existing = create(:player_selection)
     new_hero = create(:hero, name: 'Orisa')
     ps = PlayerSelection.new(map_segment: existing.map_segment,
-                             composition: existing.composition,
-                             player: existing.player,
+                             composition_player: existing.composition_player,
                              hero: new_hero)
     expect(ps.valid?).to be_falsey
-    expect(ps.errors[:player_id].any?).to be_truthy
+    expect(ps.errors[:composition_player_id].any?).to be_truthy
   end
 end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -7,6 +7,23 @@ describe Player do
     expect(player.errors[:name].any?).to be_truthy
   end
 
+  it 'requires a unique name per authenticated creator' do
+    user = create(:user)
+    player1 = create(:player, creator: user)
+    player2 = build(:player, creator: user, name: player1.name)
+    expect(player2.valid?).to be_falsey
+    expect(player2.errors[:name].any?).to be_truthy
+  end
+
+  it 'requires a unique name per anonymous creator' do
+    anon_user = create(:anonymous_user)
+    player1 = create(:player, creator: anon_user, creator_session_id: '123')
+    player2 = build(:player, creator: anon_user, name: player1.name,
+                    creator_session_id: player1.creator_session_id)
+    expect(player2.valid?).to be_falsey
+    expect(player2.errors[:name].any?).to be_truthy
+  end
+
   it 'requires a creator' do
     player = Player.new
     expect(player.valid?).to be_falsey

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -36,4 +36,32 @@ describe Player do
     expect(player.valid?).to be_falsey
     expect(player.errors[:creator_session_id].any?).to be_truthy
   end
+
+  context '#find_if_allowed' do
+    it 'returns nil when anonymous user does not own player' do
+      player = create(:player)
+      result = Player.find_if_allowed(player.id, user: nil, session_id: '123')
+      expect(result).to be_nil
+    end
+
+    it 'returns nil when authenticated user does not own player' do
+      player = create(:player)
+      result = Player.find_if_allowed(player.id, user: create(:user), session_id: nil)
+      expect(result).to be_nil
+    end
+
+    it 'returns owned player for anonymous user' do
+      anon_user = create(:anonymous_user)
+      player = create(:player, creator: anon_user, creator_session_id: '123')
+      result = Player.find_if_allowed(player.id, user: nil, session_id: '123')
+      expect(result).to eq(player)
+    end
+
+    it 'returns owned player for authenticated user' do
+      user = create(:user)
+      player = create(:player, creator: user)
+      result = Player.find_if_allowed(player.id, user: user, session_id: nil)
+      expect(result).to eq(player)
+    end
+  end
 end


### PR DESCRIPTION
This changes the data model by removing the separate `player_id` and `composition_id` fields from `player_selections` in favor of a single `composition_player_id` field. This also adds:

- Some validations:
    - A given player can only appear one time in a composition.
    - The owner of a player must match the owner of a composition when creating a CompositionPlayer record.
    - Ensure `position` is always within 0-5.
- A couple helper methods like Player#find_if_allowed that's used in `player-select-menu` #61.

This branch breaks tests. It's meant to land with #61 which updates the controllers and front end to work with the data model changes. I wanted to make #61 easier to review by making it shorter, so I pulled out some the data model changes to this branch.