### PR TITLE
Shrink map segment names in seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,13 +43,13 @@ map_segments_by_map = {
   'Lijiang Tower' => ['Night Market', 'Control Center', 'Garden'],
   'Nepal' => ['Village', 'Shrine', 'Sanctum'],
   'Oasis' => ['City Center', 'Gardens', 'University'],
-  'Hollywood' => ['Capture Point 1', 'Payload 1', 'Payload 2'],
+  'Hollywood' => ['Point 1', 'Payload 1', 'Payload 2'],
   'Dorado' => ['Payload 1', 'Payload 2', 'Payload 3'],
-  "King's Row" => ['Capture Point 1', 'Payload 1', 'Payload 2'],
-  'Numbani' => ['Capture Point 1', 'Payload 1', 'Payload 2'],
+  "King's Row" => ['Point 1', 'Payload 1', 'Payload 2'],
+  'Numbani' => ['Point 1', 'Payload 1', 'Payload 2'],
   'Route 66' => ['Payload 1', 'Payload 2', 'Payload 3'],
   'Watchpoint: Gibraltar' => ['Payload 1', 'Payload 2', 'Payload 3'],
-  'Eichenwalde' => ['Capture Point 1', 'Payload 1', 'Payload 2'],
+  'Eichenwalde' => ['Point 1', 'Payload 1', 'Payload 2'],
   'Ecopoint: Antarctica' => ['Attack']
 }
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -75,6 +75,3 @@ end
 
 puts "Creating anonymous user"
 anon_user = User.create!(email: User::ANONYMOUS_EMAIL, password: "passworD1")
-
-puts 'Creating default player'
-Player.create!(name: Player::DEFAULT_NAME, creator: anon_user)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -56,7 +56,7 @@ map_segments_by_map = {
 maps_without_defense = [
   'Ilios', 'Ecopoint: Antarctica', 'Oasis', 'Lijiang Tower', 'Nepal'
 ]
-team_roles = ['Attacking', 'Defending']
+team_roles = ['Attack', 'Defend']
 
 map_segments_by_map.each do |map_name, base_segments|
   map = Map.find_by_name(map_name)


### PR DESCRIPTION
This:

- Fixes the seeds not fully running because of a leftover bit of code I forgot to remove.
- Shortens some map segment names so they better fit when there are many map segments to show, such as for Numbani.