### PR TITLE
Propagate hero selection to all map segments on initial pick

### DIFF
--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -57,15 +57,14 @@ export default class CompositionForm extends React.Component {
     }
   }
 
-  onHeroSelectedForPlayer(heroID, mapSegmentID, player, position) {
+  onHeroSelectedForPlayer(heroID, mapSegmentID, playerID, position) {
     const { composition } = this.state
     const api = new OverwatchTeamCompsApi()
 
     const body = {
       hero_id: heroID,
       map_segment_id: mapSegmentID,
-      player_id: player.id,
-      player_name: player.name,
+      player_id: playerID,
       player_position: position
     }
     if (composition.id) {
@@ -175,7 +174,7 @@ export default class CompositionForm extends React.Component {
                     mapSegments={mapSegments}
                     nameLabel={String(index + 1)}
                     onHeroSelection={(heroID, mapSegmentID) =>
-                      this.onHeroSelectedForPlayer(heroID, mapSegmentID, player, index)
+                      this.onHeroSelectedForPlayer(heroID, mapSegmentID, player.id, index)
                     }
                     onPlayerSelection={(playerID, name) =>
                       this.onPlayerSelected(playerID, name, index)

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -59,6 +59,7 @@ export default class CompositionForm extends React.Component {
 
   onHeroSelectedForPlayer(heroID, mapSegmentID, playerID, position) {
     this.saveHeroSelection(heroID, mapSegmentID, playerID, position)
+    this.propagateHeroSelection(heroID, mapSegmentID, playerID, position)
   }
 
   onCompositionSaved(composition) {
@@ -96,6 +97,17 @@ export default class CompositionForm extends React.Component {
     api.createPlayer(body).
       then(comp => this.onCompositionSaved(comp)).
       catch(err => CompositionForm.onPlayerCreationError(err))
+  }
+
+  propagateHeroSelection(heroID, mapSegmentID, playerID, position) {
+    const { composition } = this.state
+    const playerSelections = composition.selections[playerID]
+    const mapSegmentIDs = Object.keys(playerSelections).filter(id => {
+      return id !== mapSegmentID && playerSelections[id] === null
+    })
+    for (let i = 0; i < mapSegmentIDs.length; i++) {
+      this.saveHeroSelection(heroID, mapSegmentIDs[i], playerID, position)
+    }
   }
 
   saveHeroSelection(heroID, mapSegmentID, playerID, position) {

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -58,22 +58,7 @@ export default class CompositionForm extends React.Component {
   }
 
   onHeroSelectedForPlayer(heroID, mapSegmentID, playerID, position) {
-    const { composition } = this.state
-    const api = new OverwatchTeamCompsApi()
-
-    const body = {
-      hero_id: heroID,
-      map_segment_id: mapSegmentID,
-      player_id: playerID,
-      player_position: position
-    }
-    if (composition.id) {
-      body.composition_id = composition.id
-    }
-
-    api.saveComposition(body).
-      then(newComp => this.onCompositionSaved(newComp)).
-      catch(err => CompositionForm.onCompositionSaveError(err))
+    this.saveHeroSelection(heroID, mapSegmentID, playerID, position)
   }
 
   onCompositionSaved(composition) {
@@ -111,6 +96,25 @@ export default class CompositionForm extends React.Component {
     api.createPlayer(body).
       then(comp => this.onCompositionSaved(comp)).
       catch(err => CompositionForm.onPlayerCreationError(err))
+  }
+
+  saveHeroSelection(heroID, mapSegmentID, playerID, position) {
+    const { composition } = this.state
+    const api = new OverwatchTeamCompsApi()
+
+    const body = {
+      hero_id: heroID,
+      map_segment_id: mapSegmentID,
+      player_id: playerID,
+      player_position: position
+    }
+    if (composition.id) {
+      body.composition_id = composition.id
+    }
+
+    api.saveComposition(body).
+      then(newComp => this.onCompositionSaved(newComp)).
+      catch(err => CompositionForm.onCompositionSaveError(err))
   }
 
   updatePlayer(playerID, position) {

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -50,29 +50,10 @@ export default class CompositionForm extends React.Component {
   }
 
   onPlayerSelected(playerID, playerName, position) {
-    const { composition } = this.state
-    const api = new OverwatchTeamCompsApi()
-
-    if (playerID) { // update existing player
-      const body = {
-        map_id: composition.map.id,
-        player_position: position,
-        player_id: playerID,
-        composition_id: composition.id
-      }
-      api.saveComposition(body).
-        then(newComp => this.onCompositionSaved(newComp)).
-        catch(err => CompositionForm.onCompositionSaveError(err))
-    } else { // create new player
-      const body = {
-        name: playerName,
-        composition_id: composition.id,
-        map_id: composition.map.id,
-        position
-      }
-      api.createPlayer(body).
-        then(comp => this.onCompositionSaved(comp)).
-        catch(err => CompositionForm.onPlayerCreationError(err))
+    if (playerID) {
+      this.updatePlayer(playerID, position)
+    } else {
+      this.createPlayer(playerName, position)
     }
   }
 
@@ -114,8 +95,37 @@ export default class CompositionForm extends React.Component {
   loadComposition(mapID) {
     const api = new OverwatchTeamCompsApi()
 
-    api.getLastComposition(mapID).then(comp => this.onCompositionFetched(comp)).
+    api.getLastComposition(mapID).
+      then(comp => this.onCompositionFetched(comp)).
       catch(err => CompositionForm.onCompositionFetchError(err))
+  }
+
+  createPlayer(playerName, position) {
+    const { composition } = this.state
+    const body = {
+      name: playerName,
+      composition_id: composition.id,
+      map_id: composition.map.id,
+      position
+    }
+    const api = new OverwatchTeamCompsApi()
+    api.createPlayer(body).
+      then(comp => this.onCompositionSaved(comp)).
+      catch(err => CompositionForm.onPlayerCreationError(err))
+  }
+
+  updatePlayer(playerID, position) {
+    const { composition } = this.state
+    const body = {
+      map_id: composition.map.id,
+      player_position: position,
+      player_id: playerID,
+      composition_id: composition.id
+    }
+    const api = new OverwatchTeamCompsApi()
+    api.saveComposition(body).
+      then(newComp => this.onCompositionSaved(newComp)).
+      catch(err => CompositionForm.onCompositionSaveError(err))
   }
 
   render() {

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -58,8 +58,22 @@ export default class CompositionForm extends React.Component {
   }
 
   onHeroSelectedForPlayer(heroID, mapSegmentID, playerID, position) {
-    this.saveHeroSelection(heroID, mapSegmentID, playerID, position)
-    this.propagateHeroSelection(heroID, mapSegmentID, playerID, position)
+    const { composition } = this.state
+    const api = new OverwatchTeamCompsApi()
+
+    const body = {
+      hero_id: heroID,
+      map_segment_id: mapSegmentID,
+      player_id: playerID,
+      player_position: position
+    }
+    if (composition.id) {
+      body.composition_id = composition.id
+    }
+
+    api.saveComposition(body).
+      then(newComp => this.onCompositionSaved(newComp)).
+      catch(err => CompositionForm.onCompositionSaveError(err))
   }
 
   onCompositionSaved(composition) {
@@ -97,36 +111,6 @@ export default class CompositionForm extends React.Component {
     api.createPlayer(body).
       then(comp => this.onCompositionSaved(comp)).
       catch(err => CompositionForm.onPlayerCreationError(err))
-  }
-
-  propagateHeroSelection(heroID, mapSegmentID, playerID, position) {
-    const { composition } = this.state
-    const playerSelections = composition.selections[playerID]
-    const mapSegmentIDs = Object.keys(playerSelections).filter(id => {
-      return id !== mapSegmentID && playerSelections[id] === null
-    })
-    for (let i = 0; i < mapSegmentIDs.length; i++) {
-      this.saveHeroSelection(heroID, mapSegmentIDs[i], playerID, position)
-    }
-  }
-
-  saveHeroSelection(heroID, mapSegmentID, playerID, position) {
-    const { composition } = this.state
-    const api = new OverwatchTeamCompsApi()
-
-    const body = {
-      hero_id: heroID,
-      map_segment_id: mapSegmentID,
-      player_id: playerID,
-      player_position: position
-    }
-    if (composition.id) {
-      body.composition_id = composition.id
-    }
-
-    api.saveComposition(body).
-      then(newComp => this.onCompositionSaved(newComp)).
-      catch(err => CompositionForm.onCompositionSaveError(err))
   }
 
   updatePlayer(playerID, position) {

--- a/app/assets/javascripts/components/edit-player-selection-row.jsx
+++ b/app/assets/javascripts/components/edit-player-selection-row.jsx
@@ -1,35 +1,33 @@
 import HeroSelect from './hero-select.jsx'
 import PlayerSelect from './player-select.jsx'
 
-class EditPlayerSelectionRow extends React.Component {
-  render() {
-    const { inputID, selectedPlayer, nameLabel, onHeroSelection,
-            mapSegments, onPlayerSelection, players, heroes,
-            selections } = this.props
-    return (
-      <tr>
-        <td className="player-cell">
-          <PlayerSelect
-            inputID={inputID}
-            label={nameLabel}
-            selectedPlayer={selectedPlayer}
-            players={players}
-            onChange={(playerID, name) => onPlayerSelection(playerID, name)}
+const EditPlayerSelectionRow = function(props) {
+  const { inputID, selectedPlayer, nameLabel, onHeroSelection,
+          mapSegments, onPlayerSelection, players, heroes,
+          selections } = props
+  return (
+    <tr>
+      <td className="player-cell">
+        <PlayerSelect
+          inputID={inputID}
+          label={nameLabel}
+          selectedPlayer={selectedPlayer}
+          players={players}
+          onChange={(playerID, name) => onPlayerSelection(playerID, name)}
+        />
+      </td>
+      {mapSegments.map(segment => (
+        <td key={segment.id} className="hero-select-cell">
+          <HeroSelect
+            heroes={heroes}
+            disabled={typeof selectedPlayer.id !== 'number'}
+            selectedHeroID={selections[segment.id]}
+            onChange={heroID => onHeroSelection(heroID, segment.id)}
           />
         </td>
-        {mapSegments.map(segment => (
-          <td key={segment.id} className="hero-select-cell">
-            <HeroSelect
-              heroes={heroes}
-              disabled={typeof selectedPlayer.id !== 'number'}
-              selectedHeroID={selections[segment.id]}
-              onChange={heroID => onHeroSelection(heroID, segment.id)}
-            />
-          </td>
-        ))}
-      </tr>
-    )
-  }
+      ))}
+    </tr>
+  )
 }
 
 EditPlayerSelectionRow.propTypes = {

--- a/app/controllers/compositions_controller.rb
+++ b/app/controllers/compositions_controller.rb
@@ -34,8 +34,8 @@ class CompositionsController < ApplicationController
   private
 
   def composition_params
-    params.permit(:player_name, :composition_id, :hero_id, :map_segment_id,
-                  :player_id, :player_position, :map_id)
+    params.permit(:composition_id, :hero_id, :map_segment_id, :player_id,
+                  :player_position, :map_id)
   end
 
   def most_recent_composition

--- a/app/views/compositions/show.json.jbuilder
+++ b/app/views/compositions/show.json.jbuilder
@@ -22,7 +22,7 @@ json.composition do
       json.id row.player.id
       json.name row.player.name
     else
-      json.name 'Player'
+      json.name ''
     end
   end
 


### PR DESCRIPTION
Fixes #68 by propagating your initial hero pick to all points on the map for that player. This is a convenience for the user so they don't have to go through each map point and choose the same hero for a teammate who will be staying on that same hero for the whole game.

Also improves the experience for creating a new player on your team by starting the player name field blank instead of with 'Player' text that you first have to erase.