### PR TITLE
Allow updating composition name

### DIFF
--- a/app/assets/javascripts/components/composition-form-header.jsx
+++ b/app/assets/javascripts/components/composition-form-header.jsx
@@ -133,8 +133,8 @@ class CompositionHeader extends React.Component {
 }
 
 CompositionHeader.propTypes = {
-  name: React.PropTypes.string.isRequired,
-  slug: React.PropTypes.string.isRequired,
+  name: React.PropTypes.string,
+  slug: React.PropTypes.string,
   mapID: React.PropTypes.number.isRequired,
   onMapChange: React.PropTypes.func.isRequired,
   onNameChange: React.PropTypes.func.isRequired

--- a/app/assets/javascripts/components/composition-form-header.jsx
+++ b/app/assets/javascripts/components/composition-form-header.jsx
@@ -7,7 +7,7 @@ class CompositionHeader extends React.Component {
 
   constructor(props) {
     super(props)
-    this.state = {}
+    this.state = { name: props.name, editingName: false }
   }
 
   componentDidMount() {
@@ -15,6 +15,14 @@ class CompositionHeader extends React.Component {
 
     api.getMaps().then(maps => this.onMapsFetched(maps)).
       catch(err => CompositionHeader.onMapsError(err))
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({ name: nextProps.name, editingName: false })
+  }
+
+  onNameChange(event) {
+    this.setState({ name: event.target.value })
   }
 
   onMapsFetched(maps) {
@@ -25,13 +33,63 @@ class CompositionHeader extends React.Component {
     this.props.onMapChange(event.target.value)
   }
 
+  saveNewName(event) {
+    event.preventDefault()
+    event.target.closest('button').blur() // defocus the button
+    const { name } = this.state
+    if (name.trim().length < 1) {
+      return
+    }
+    this.props.onNameChange(name)
+  }
+
+  nameEditArea() {
+    const { editingName, name } = this.state
+    let pencilIcon = null
+    let saveButton = null
+
+    if (editingName) {
+      saveButton = (
+        <button
+          type="button"
+          className="button save-composition-name-button"
+          onClick={e => this.saveNewName(e)}
+        ><i className="fa fa-check" aria-hidden="true" /></button>
+      )
+    } else {
+      pencilIcon = (
+        <i
+          className="fa fa-pencil-square-o"
+          aria-hidden="true"
+        />
+      )
+    }
+
+    return (
+      <div className={`composition-name-container ${editingName ? 'editing' : ''}`}>
+        {pencilIcon}
+        <input
+          type="text"
+          className="input composition-name-input"
+          placeholder="Composition name"
+          id="composition_name"
+          value={name || ''}
+          onChange={e => this.onNameChange(e)}
+          onFocus={() => this.setState({ editingName: true })}
+          aria-label="Name of this team composition"
+        />
+        {saveButton}
+      </div>
+    )
+  }
+
   render() {
     const { maps } = this.state
     if (typeof maps === 'undefined') {
       return null
     }
 
-    const { composition } = this.props
+    const { mapID, slug } = this.props
     return (
       <header className="composition-header">
         <div className="container">
@@ -42,7 +100,7 @@ class CompositionHeader extends React.Component {
                 <select
                   aria-label="Choose a map"
                   id="composition_map_id"
-                  value={composition.map.id}
+                  value={mapID}
                   onChange={e => this.onMapChange(e)}
                 >
                   {maps.map(map =>
@@ -54,24 +112,10 @@ class CompositionHeader extends React.Component {
                 </select>
               </span>
             </div>
-            <div className="composition-name-container">
-              <i
-                className="fa fa-pencil-square-o"
-                aria-hidden="true"
-              />
-              <input
-                type="text"
-                className="input composition-name-input"
-                placeholder="Composition name"
-                id="composition_name"
-                value={composition.name || ''}
-                onChange={e => this.onCompositionNameChange(e)}
-                aria-label="Name of this team composition"
-              />
-            </div>
+            {this.nameEditArea()}
             <div className="composition-link-container">
               <a
-                href={`/comp/${composition.slug}`}
+                href={`/comp/${slug}`}
                 className="composition-link"
               >
                 <i
@@ -89,8 +133,11 @@ class CompositionHeader extends React.Component {
 }
 
 CompositionHeader.propTypes = {
-  composition: React.PropTypes.object.isRequired,
-  onMapChange: React.PropTypes.func.isRequired
+  name: React.PropTypes.string.isRequired,
+  slug: React.PropTypes.string.isRequired,
+  mapID: React.PropTypes.number.isRequired,
+  onMapChange: React.PropTypes.func.isRequired,
+  onNameChange: React.PropTypes.func.isRequired
 }
 
 export default CompositionHeader

--- a/app/assets/javascripts/components/composition-form-header.jsx
+++ b/app/assets/javascripts/components/composition-form-header.jsx
@@ -83,13 +83,35 @@ class CompositionHeader extends React.Component {
     )
   }
 
+  shareLink() {
+    const { slug } = this.props
+    if (typeof slug !== 'string' || slug.length < 1) {
+      return null
+    }
+
+    return (
+      <div className="composition-link-container">
+        <a
+          href={`/comp/${slug}`}
+          className="composition-link"
+        >
+          <i
+            className="fa fa-link"
+            aria-hidden="true"
+          />
+          Share this composition
+        </a>
+      </div>
+    )
+  }
+
   render() {
     const { maps } = this.state
     if (typeof maps === 'undefined') {
       return null
     }
 
-    const { mapID, slug } = this.props
+    const { mapID } = this.props
     return (
       <header className="composition-header">
         <div className="container">
@@ -113,18 +135,7 @@ class CompositionHeader extends React.Component {
               </span>
             </div>
             {this.nameEditArea()}
-            <div className="composition-link-container">
-              <a
-                href={`/comp/${slug}`}
-                className="composition-link"
-              >
-                <i
-                  className="fa fa-link"
-                  aria-hidden="true"
-                />
-                Share this composition
-              </a>
-            </div>
+            {this.shareLink()}
           </div>
         </div>
       </header>

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -199,7 +199,8 @@ export default class CompositionForm extends React.Component {
                   <EditPlayerSelectionRow
                     key={key}
                     inputID={inputID}
-                    selectedPlayer={player}
+                    playerID={player.id}
+                    playerName={player.name}
                     players={selectablePlayers}
                     heroes={playerHeroes}
                     selections={playerSelections}

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -55,17 +55,10 @@ export default class CompositionForm extends React.Component {
   }
 
   onCompositionNotesChange(event) {
-    const { id } = this.state
-    const api = new OverwatchTeamCompsApi()
-
-    const body = { notes: event.target.value }
-    if (id) {
-      body.composition_id = id
-    }
-
-    api.saveComposition(body).
-      then(newComp => this.onCompositionLoaded(newComp)).
-      catch(err => CompositionForm.onCompositionSaveError(err))
+    // TODO: actually POST this to the server to save the value,
+    // but not as the user types because we don't want a request
+    // going for every keystroke
+    this.setState({ notes: event.target.value })
   }
 
   onPlayerSelected(playerID, playerName, position) {

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -41,10 +41,13 @@ export default class CompositionForm extends React.Component {
   }
 
   onCompositionNameChange(name) {
-    const { id } = this.state
+    const { id, mapID } = this.state
     const api = new OverwatchTeamCompsApi()
 
-    const body = { name }
+    const body = {
+      name,
+      map_id: mapID
+    }
     if (id) {
       body.composition_id = id
     }

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -1,5 +1,3 @@
-import update from 'immutability-helper'
-
 import CompositionFormHeader from './composition-form-header.jsx'
 import EditPlayerSelectionRow from './edit-player-selection-row.jsx'
 import MapSegmentHeader from './map-segment-header.jsx'
@@ -20,33 +18,54 @@ export default class CompositionForm extends React.Component {
 
   constructor() {
     super()
-    this.state = {}
+    this.state = {
+      id: null,
+      name: '',
+      slug: '',
+      mapID: null,
+      mapSegments: [],
+      players: [],
+      availablePlayers: [],
+      heroes: {},
+      selections: {},
+      notes: ''
+    }
   }
 
   componentDidMount() {
     this.loadComposition()
   }
 
-  onCompositionFetched(composition) {
-    this.setState({ composition })
-  }
-
   onMapChange(mapID) {
     this.loadComposition(mapID)
   }
 
-  onCompositionNameChange(event) {
-    const name = event.target.value
-    const changes = { name: { $set: name } }
-    const composition = update(this.state.composition, changes)
-    this.setState({ composition })
+  onCompositionNameChange(name) {
+    const { id } = this.state
+    const api = new OverwatchTeamCompsApi()
+
+    const body = { name }
+    if (id) {
+      body.composition_id = id
+    }
+
+    api.saveComposition(body).
+      then(newComp => this.onCompositionLoaded(newComp)).
+      catch(err => CompositionForm.onCompositionSaveError(err))
   }
 
   onCompositionNotesChange(event) {
-    const notes = event.target.value
-    const changes = { notes: { $set: notes } }
-    const composition = update(this.state.composition, changes)
-    this.setState({ composition })
+    const { id } = this.state
+    const api = new OverwatchTeamCompsApi()
+
+    const body = { notes: event.target.value }
+    if (id) {
+      body.composition_id = id
+    }
+
+    api.saveComposition(body).
+      then(newComp => this.onCompositionLoaded(newComp)).
+      catch(err => CompositionForm.onCompositionSaveError(err))
   }
 
   onPlayerSelected(playerID, playerName, position) {
@@ -58,7 +77,7 @@ export default class CompositionForm extends React.Component {
   }
 
   onHeroSelectedForPlayer(heroID, mapSegmentID, playerID, position) {
-    const { composition } = this.state
+    const { id } = this.state
     const api = new OverwatchTeamCompsApi()
 
     const body = {
@@ -67,24 +86,34 @@ export default class CompositionForm extends React.Component {
       player_id: playerID,
       player_position: position
     }
-    if (composition.id) {
-      body.composition_id = composition.id
+    if (id) {
+      body.composition_id = id
     }
 
     api.saveComposition(body).
-      then(newComp => this.onCompositionSaved(newComp)).
+      then(newComp => this.onCompositionLoaded(newComp)).
       catch(err => CompositionForm.onCompositionSaveError(err))
   }
 
-  onCompositionSaved(composition) {
-    this.setState({ composition })
+  onCompositionLoaded(composition) {
+    this.setState({
+      id: composition.id,
+      name: composition.name,
+      slug: composition.slug,
+      mapID: composition.map.id,
+      mapSegments: composition.map.segments,
+      players: composition.players,
+      availablePlayers: composition.availablePlayers,
+      heroes: composition.heroes,
+      selections: composition.selections,
+      notes: composition.notes
+    })
   }
 
   // Returns a list of players. Includes only players not selected in
   // other rows. Always includes the given player.
   getPlayerOptionsForRow(playerForRow) {
-    const { composition } = this.state
-    const { availablePlayers, players } = composition
+    const { availablePlayers, players } = this.state
     const playerIDsInComp = players.map(player => player.id)
     return availablePlayers.filter(player =>
       playerIDsInComp.indexOf(player.id) < 0 || player.id === playerForRow.id
@@ -95,51 +124,54 @@ export default class CompositionForm extends React.Component {
     const api = new OverwatchTeamCompsApi()
 
     api.getLastComposition(mapID).
-      then(comp => this.onCompositionFetched(comp)).
+      then(comp => this.onCompositionLoaded(comp)).
       catch(err => CompositionForm.onCompositionFetchError(err))
   }
 
   createPlayer(playerName, position) {
-    const { composition } = this.state
+    const { id, mapID } = this.state
     const body = {
       name: playerName,
-      composition_id: composition.id,
-      map_id: composition.map.id,
+      composition_id: id,
+      map_id: mapID,
       position
     }
     const api = new OverwatchTeamCompsApi()
     api.createPlayer(body).
-      then(comp => this.onCompositionSaved(comp)).
+      then(comp => this.onCompositionLoaded(comp)).
       catch(err => CompositionForm.onPlayerCreationError(err))
   }
 
   updatePlayer(playerID, position) {
-    const { composition } = this.state
+    const { mapID, id } = this.state
     const body = {
-      map_id: composition.map.id,
+      map_id: mapID,
       player_position: position,
       player_id: playerID,
-      composition_id: composition.id
+      composition_id: id
     }
     const api = new OverwatchTeamCompsApi()
     api.saveComposition(body).
-      then(newComp => this.onCompositionSaved(newComp)).
+      then(newComp => this.onCompositionLoaded(newComp)).
       catch(err => CompositionForm.onCompositionSaveError(err))
   }
 
   render() {
-    const { composition } = this.state
+    const { name, slug, mapID, mapSegments, players, heroes,
+            selections, notes } = this.state
 
-    if (typeof composition === 'undefined') {
+    if (typeof mapID !== 'number') {
       return <p className="container">Loading...</p>
     }
 
-    const mapSegments = composition.map.segments
     return (
       <form className="composition-form">
         <CompositionFormHeader
-          composition={composition}
-          onMapChange={mapID => this.onMapChange(mapID)}
+          name={name}
+          slug={slug}
+          mapID={mapID}
+          onNameChange={newName => this.onCompositionNameChange(newName)}
+          onMapChange={newMapID => this.onMapChange(newMapID)}
         />
         <div className="container">
           <table className="players-table">
@@ -156,28 +188,28 @@ export default class CompositionForm extends React.Component {
               </tr>
             </thead>
             <tbody>
-              {composition.players.map((player, index) => {
+              {players.map((player, index) => {
                 const inputID = `player_${index}_name`
                 const key = `${player.name}${index}`
-                const heroes = typeof player.id === 'number' ? composition.heroes[player.id] : []
-                const selections = typeof player.id === 'number' ? composition.selections[player.id] : {}
-                const players = this.getPlayerOptionsForRow(player)
+                const playerHeroes = typeof player.id === 'number' ? heroes[player.id] : []
+                const playerSelections = typeof player.id === 'number' ? selections[player.id] : {}
+                const selectablePlayers = this.getPlayerOptionsForRow(player)
 
                 return (
                   <EditPlayerSelectionRow
                     key={key}
                     inputID={inputID}
                     selectedPlayer={player}
-                    players={players}
-                    heroes={heroes}
-                    selections={selections}
+                    players={selectablePlayers}
+                    heroes={playerHeroes}
+                    selections={playerSelections}
                     mapSegments={mapSegments}
                     nameLabel={String(index + 1)}
                     onHeroSelection={(heroID, mapSegmentID) =>
                       this.onHeroSelectedForPlayer(heroID, mapSegmentID, player.id, index)
                     }
-                    onPlayerSelection={(playerID, name) =>
-                      this.onPlayerSelected(playerID, name, index)
+                    onPlayerSelection={(playerID, newName) =>
+                      this.onPlayerSelected(playerID, newName, index)
                     }
                   />
                 )
@@ -192,7 +224,7 @@ export default class CompositionForm extends React.Component {
               id="composition_notes"
               className="textarea"
               placeholder="Notes for this team composition"
-              value={composition.notes || ''}
+              value={notes || ''}
               onChange={e => this.onCompositionNotesChange(e)}
             />
             <p>

--- a/app/assets/javascripts/components/composition-view.jsx
+++ b/app/assets/javascripts/components/composition-view.jsx
@@ -18,7 +18,17 @@ class CompositionView extends React.Component {
 
   constructor(props) {
     super(props)
-    this.state = {}
+    this.state = {
+      notes: null,
+      battletag: null,
+      mapSegments: [],
+      updatedAt: null,
+      name: null,
+      mapName: null,
+      players: [],
+      selections: {},
+      heroes: {}
+    }
   }
 
   componentDidMount() {
@@ -30,11 +40,21 @@ class CompositionView extends React.Component {
   }
 
   onCompositionFetched(composition) {
-    this.setState({ composition })
+    this.setState({
+      notes: composition.notes,
+      battletag: composition.user.battletag,
+      mapSegments: composition.map.segments,
+      updatedAt: composition.updatedAt,
+      name: composition.name,
+      mapName: composition.map.name,
+      players: composition.players,
+      selections: composition.selections,
+      heroes: composition.heroes
+    })
   }
 
   compositionCreator() {
-    const battletag = this.state.composition.user.battletag
+    const { battletag } = this.state
     if (typeof battletag !== 'string' || battletag.length < 1) {
       return null
     }
@@ -46,7 +66,7 @@ class CompositionView extends React.Component {
   }
 
   compositionDate() {
-    const date = new Date(this.state.composition.updatedAt)
+    const date = new Date(this.state.updatedAt)
     const day = date.getDay()
     const dayOfMonth = date.getDate()
     const month = date.getMonth()
@@ -57,13 +77,13 @@ class CompositionView extends React.Component {
   }
 
   render() {
-    const { composition } = this.state
+    const { mapName, mapSegments, name, players, selections,
+            heroes, notes } = this.state
 
-    if (typeof composition === 'undefined') {
+    if (typeof mapName === 'undefined') {
       return <p className="container">Loading...</p>
     }
 
-    const mapSegments = composition.map.segments
     return (
       <div>
         <header className="composition-header">
@@ -71,10 +91,10 @@ class CompositionView extends React.Component {
             <div className="map-photo-container" />
             <div className="composition-meta">
               <div className="composition-map-name">
-                {composition.map.name}
+                {mapName}
               </div>
               <div className="composition-name">
-                {composition.name}
+                {name}
               </div>
               <div className="composition-creator-and-date">
                 {this.compositionCreator()}
@@ -98,17 +118,17 @@ class CompositionView extends React.Component {
               </tr>
             </thead>
             <tbody>
-              {composition.players.map((player, index) => {
+              {players.map((player, index) => {
                 const key = `${player.name}${index}`
-                const selections = typeof player.id === 'number' ? composition.selections[player.id] : {}
-                const heroes = typeof player.id === 'number' ? composition.heroes[player.id] : []
+                const playerSelections = typeof player.id === 'number' ? selections[player.id] : {}
+                const playerHeroes = typeof player.id === 'number' ? heroes[player.id] : []
 
                 return (
                   <PlayerRowView
                     key={key}
-                    player={player}
-                    heroes={heroes}
-                    selections={selections}
+                    name={player.name}
+                    heroes={playerHeroes}
+                    selections={playerSelections}
                     mapSegments={mapSegments}
                   />
                 )
@@ -118,7 +138,7 @@ class CompositionView extends React.Component {
           <div className="composition-notes-wrapper">
             <p>Notes:</p>
             <div>
-              {composition.notes}
+              {notes}
             </div>
           </div>
         </div>

--- a/app/assets/javascripts/components/edit-player-selection-row.jsx
+++ b/app/assets/javascripts/components/edit-player-selection-row.jsx
@@ -2,7 +2,7 @@ import HeroSelect from './hero-select.jsx'
 import PlayerSelect from './player-select.jsx'
 
 const EditPlayerSelectionRow = function(props) {
-  const { inputID, selectedPlayer, nameLabel, onHeroSelection,
+  const { inputID, playerID, playerName, nameLabel, onHeroSelection,
           mapSegments, onPlayerSelection, players, heroes,
           selections } = props
   return (
@@ -11,9 +11,12 @@ const EditPlayerSelectionRow = function(props) {
         <PlayerSelect
           inputID={inputID}
           label={nameLabel}
-          selectedPlayer={selectedPlayer}
+          playerID={playerID}
+          name={playerName}
           players={players}
-          onChange={(playerID, name) => onPlayerSelection(playerID, name)}
+          onChange={(newPlayerID, newName) =>
+            onPlayerSelection(newPlayerID, newName)
+          }
         />
       </td>
       {mapSegments.map((segment, i) => (
@@ -23,7 +26,7 @@ const EditPlayerSelectionRow = function(props) {
         >
           <HeroSelect
             heroes={heroes}
-            disabled={typeof selectedPlayer.id !== 'number'}
+            disabled={typeof playerID !== 'number'}
             selectedHeroID={selections[segment.id]}
             onChange={heroID => onHeroSelection(heroID, segment.id)}
           />
@@ -35,7 +38,8 @@ const EditPlayerSelectionRow = function(props) {
 
 EditPlayerSelectionRow.propTypes = {
   inputID: React.PropTypes.string.isRequired,
-  selectedPlayer: React.PropTypes.object.isRequired,
+  playerID: React.PropTypes.number,
+  playerName: React.PropTypes.string.isRequired,
   players: React.PropTypes.array.isRequired,
   onPlayerSelection: React.PropTypes.func.isRequired,
   nameLabel: React.PropTypes.string.isRequired,

--- a/app/assets/javascripts/components/hero-pool-choice.jsx
+++ b/app/assets/javascripts/components/hero-pool-choice.jsx
@@ -4,26 +4,26 @@ class HeroPoolChoice extends React.Component {
   }
 
   render() {
-    const { hero, ranks } = this.props
+    const { slug, image, name, id, ranks, confidence } = this.props
     const rankNames = Object.keys(ranks)
 
     return (
       <div className="hero-pool-choice">
-        <div className={`hero-pool-hero border-${hero.slug}`}>
+        <div className={`hero-pool-hero border-${slug}`}>
           <img
-            src={hero.image}
-            alt={hero.name}
+            src={image}
+            alt={name}
             className="hero-pool-portrait"
           />
         </div>
         <div className="hero-pool-inputs-container">
           <h3
-            className={`hero-pool-hero-name text-${hero.slug}`}
-          >{hero.name}</h3>
+            className={`hero-pool-hero-name text-${slug}`}
+          >{name}</h3>
           <div className="competitive-ranks-container">
             {rankNames.map(rankName => {
-              const confidence = ranks[rankName].confidence
-              const inputID = `${hero.id}${confidence}`
+              const rankConfidence = ranks[rankName].confidence
+              const inputID = `${id}${rankConfidence}`
               return (
                 <div
                   key={rankName}
@@ -31,11 +31,11 @@ class HeroPoolChoice extends React.Component {
                 >
                   <input
                     id={inputID}
-                    name={hero.name}
+                    name={name}
                     className="hero-pool-radio"
                     type="radio"
-                    checked={hero.confidence === confidence}
-                    value={confidence}
+                    checked={confidence === rankConfidence}
+                    value={rankConfidence}
                     onChange={e => this.onChange(e)}
                   />
                   <label
@@ -65,7 +65,11 @@ class HeroPoolChoice extends React.Component {
 }
 
 HeroPoolChoice.propTypes = {
-  hero: React.PropTypes.object.isRequired,
+  slug: React.PropTypes.string.isRequired,
+  image: React.PropTypes.string.isRequired,
+  id: React.PropTypes.number.isRequired,
+  confidence: React.PropTypes.number.isRequired,
+  name: React.PropTypes.string.isRequired,
   onChange: React.PropTypes.func.isRequired,
   ranks: React.PropTypes.object.isRequired
 }

--- a/app/assets/javascripts/components/hero-pool-form.jsx
+++ b/app/assets/javascripts/components/hero-pool-form.jsx
@@ -55,10 +55,16 @@ class HeroPoolForm extends React.Component {
           <div>
             {heroes.map(hero => (
               <HeroPoolChoice
-                hero={hero}
+                slug={hero.slug}
+                image={hero.image}
+                name={hero.name}
+                id={hero.id}
+                confidence={hero.confidence}
                 key={hero.id}
                 ranks={ranks}
-                onChange={confidence => this.onConfidenceChange(hero.id, confidence)}
+                onChange={newConfidence =>
+                  this.onConfidenceChange(hero.id, newConfidence)
+                }
               />
             ))}
           </div>

--- a/app/assets/javascripts/components/hero-select.jsx
+++ b/app/assets/javascripts/components/hero-select.jsx
@@ -7,7 +7,11 @@ class HeroSelect extends React.Component {
   heroPortrait() {
     const { heroes, selectedHeroID } = this.props
     if (typeof selectedHeroID !== 'number') {
-      return <span className="hero-portrait-placeholder" />
+      return (
+        <span className="hero-portrait-placeholder">
+          <i className="fa fa-user-o" aria-hidden="true"></i>
+        </span>
+      )
     }
     const hero = heroes.filter(h => h.id === selectedHeroID)[0]
     return (
@@ -30,7 +34,7 @@ class HeroSelect extends React.Component {
             value={selectedHeroID || ''}
             disabled={disabled}
           >
-            <option>Choose a hero</option>
+            <option>Hero</option>
             {heroes.map(hero => (
               <option
                 key={hero.id}

--- a/app/assets/javascripts/components/hero-select.jsx
+++ b/app/assets/javascripts/components/hero-select.jsx
@@ -9,7 +9,7 @@ class HeroSelect extends React.Component {
     if (typeof selectedHeroID !== 'number') {
       return (
         <span className="hero-portrait-placeholder">
-          <i className="fa fa-user-o" aria-hidden="true"></i>
+          <i className="fa fa-user-o" aria-hidden="true" />
         </span>
       )
     }

--- a/app/assets/javascripts/components/hero-select.jsx
+++ b/app/assets/javascripts/components/hero-select.jsx
@@ -8,9 +8,7 @@ class HeroSelect extends React.Component {
     const { heroes, selectedHeroID } = this.props
     if (typeof selectedHeroID !== 'number') {
       return (
-        <span className="hero-portrait-placeholder">
-          <i className="fa fa-user-o" aria-hidden="true" />
-        </span>
+        <span className="hero-portrait-placeholder" />
       )
     }
     const hero = heroes.filter(h => h.id === selectedHeroID)[0]

--- a/app/assets/javascripts/components/player-row-view.jsx
+++ b/app/assets/javascripts/components/player-row-view.jsx
@@ -27,8 +27,8 @@ class PlayerRowView extends React.Component {
   }
 
   playerCell() {
-    const { player } = this.props
-    if (player.name.length < 1) {
+    const { name } = this.props
+    if (name.length < 1) {
       return (
         <td className="empty-selection player-cell">
           &mdash;
@@ -38,7 +38,7 @@ class PlayerRowView extends React.Component {
 
     return (
       <td className="player-cell">
-        {player.name}
+        {name}
       </td>
     )
   }
@@ -56,7 +56,7 @@ class PlayerRowView extends React.Component {
 
 PlayerRowView.propTypes = {
   heroes: React.PropTypes.array.isRequired,
-  player: React.PropTypes.object.isRequired,
+  name: React.PropTypes.string.isRequired,
   selections: React.PropTypes.object.isRequired,
   mapSegments: React.PropTypes.array.isRequired
 }

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -8,6 +8,13 @@ class PlayerSelect extends React.Component {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      name: nextProps.selectedPlayer.name,
+      showNewNameField: false
+    })
+  }
+
   onChange(event) {
     const playerID = event.target.value
     if (playerID === 'new') {

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -65,7 +65,7 @@ class PlayerSelect extends React.Component {
           onChange={e => this.onChange(e)}
           value={typeof playerID === 'number' ? playerID : ''}
         >
-          <option value="">Choose a player</option>
+          <option value="">Player</option>
           {players.map(player => (
             <option
               key={player.id}

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -2,25 +2,19 @@ class PlayerSelect extends React.Component {
   constructor(props) {
     super(props)
 
-    this.state = {
-      name: props.selectedPlayer.name,
-      showNewNameField: false
-    }
+    this.state = { name: props.name, showNewNameField: false }
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({
-      name: nextProps.selectedPlayer.name,
-      showNewNameField: false
-    })
+    this.setState({ name: nextProps.name, showNewNameField: false })
   }
 
   onChange(event) {
-    const playerID = event.target.value
-    if (playerID === 'new') {
+    const newPlayerID = event.target.value
+    if (newPlayerID === 'new') {
       this.setState({ showNewNameField: true })
     } else {
-      this.props.onChange(playerID, null)
+      this.props.onChange(newPlayerID, null)
     }
   }
 
@@ -42,7 +36,7 @@ class PlayerSelect extends React.Component {
   }
 
   selectOrTextField() {
-    const { selectedPlayer, inputID, players } = this.props
+    const { playerID, inputID, players } = this.props
 
     if (this.state.showNewNameField) {
       return (
@@ -69,7 +63,7 @@ class PlayerSelect extends React.Component {
       <span className="select player-select">
         <select
           onChange={e => this.onChange(e)}
-          value={typeof selectedPlayer.id === 'number' ? selectedPlayer.id : ''}
+          value={typeof playerID === 'number' ? playerID : ''}
         >
           <option value="">Choose a player</option>
           {players.map(player => (
@@ -100,7 +94,8 @@ class PlayerSelect extends React.Component {
 
 PlayerSelect.propTypes = {
   inputID: React.PropTypes.string.isRequired,
-  selectedPlayer: React.PropTypes.object.isRequired,
+  playerID: React.PropTypes.number,
+  name: React.PropTypes.string.isRequired,
   players: React.PropTypes.array.isRequired,
   onChange: React.PropTypes.func.isRequired,
   label: React.PropTypes.string.isRequired

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -36,13 +36,13 @@
   .hero-select-cell {
     color: #292b31;
     white-space: nowrap;
+    padding-top: 1px;
   }
 
   .player-cell {
     background-color: #f5f5f6;
     color: #292b31;
     white-space: nowrap;
-    padding-right: 0.5em;
   }
 
   tbody td {
@@ -50,7 +50,7 @@
   }
 
   thead th {
-    padding: 0 0 15px;
+    padding: 0.5em 20px;
   }
 }
 
@@ -66,11 +66,18 @@
     display: inline-block;
     width: 40px;
     @include border-radius(3px);
-    padding-left: 5px;
+    margin-left: 0.75em;
   }
 
   .hero-portrait-placeholder {
-    background-color: #ddd;
+    height: 40px;
+    text-align: center;
+
+    .fa {
+      line-height: 40px;
+      font-size: 1.5rem;
+      color: $soft-text;
+    }
   }
 
   .player-cell {
@@ -83,6 +90,7 @@
 
     .select select {
       padding-left: 0.25em;
+      padding-right: 0;
     }
 
     .input {

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -35,6 +35,7 @@
 
   .hero-select-cell {
     color: #292b31;
+    white-space: nowrap;
   }
 
   .player-cell {

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -120,17 +120,6 @@
   }
 }
 
-.input.composition-name-input {
-  background-color: transparent;
-  color: $soft-header;
-  border: none;
-  padding-left: 0;
-  padding-right: 20px;
-  font-size: 1.3rem;
-  line-height: 1;
-  height: auto;
-}
-
 .composition-name-container {
   position: relative;
 
@@ -140,6 +129,36 @@
     top: 50%;
     margin-top: -6px;
     color: $text;
+  }
+
+  .button.save-composition-name-button {
+    background-color: inherit;
+
+    .fa {
+      color: $white;
+    }
+  }
+
+  .input.composition-name-input {
+    background-color: transparent;
+    color: $soft-header;
+    border: none;
+    padding-left: 0;
+    padding-right: 20px;
+    font-size: 1.3rem;
+    line-height: 1;
+    height: auto;
+    @include border-radius(0);
+  }
+
+  &.editing {
+    @include display-flex;
+    @include justify-content(flex-start);
+
+    .input.composition-name-input {
+      border-bottom: 1px solid $defend;
+      color: $white;
+    }
   }
 }
 

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -8,10 +8,7 @@
   font-size: 1rem;
   height: 2.25em;
   line-height: 1.5;
-  padding-bottom: 0.375em;
-  padding-left: 0.625em;
-  padding-right: 0.625em;
-  padding-top: 0.375em;
+  padding: 0.375em 0.75em;
   position: relative;
   vertical-align: top;
   -webkit-touch-callout: none;
@@ -19,8 +16,6 @@
   background-color: $white;
   color: $text;
   cursor: pointer;
-  padding-left: 0.75em;
-  padding-right: 0.75em;
   text-align: center;
   white-space: nowrap;
 

--- a/app/controllers/compositions_controller.rb
+++ b/app/controllers/compositions_controller.rb
@@ -41,7 +41,7 @@ class CompositionsController < ApplicationController
 
   def composition_params
     params.permit(:composition_id, :hero_id, :map_segment_id, :player_id,
-                  :player_position, :map_id)
+                  :player_position, :map_id, :name, :notes)
   end
 
   def most_recent_composition

--- a/app/models/composition_saver.rb
+++ b/app/models/composition_saver.rb
@@ -16,7 +16,7 @@ class CompositionSaver
       Map.find(data[:map_id])
     end
 
-    if data[:composition_id] || map
+    if data[:composition_id] || data[:name] || data[:notes] || map
       @composition = init_composition(data, map: map)
       unless @composition.persisted? && !@composition.changed? || @composition.save
         @error_type = 'composition'

--- a/app/models/composition_saver.rb
+++ b/app/models/composition_saver.rb
@@ -18,7 +18,7 @@ class CompositionSaver
 
     if data[:composition_id] || map
       @composition = init_composition(data, map: map)
-      unless @composition.persisted? || @composition.save
+      unless @composition.persisted? && !@composition.changed? || @composition.save
         @error_type = 'composition'
         @error_value = @composition.errors
         return
@@ -77,7 +77,20 @@ class CompositionSaver
       raise CompositionSaver::Error, 'No such composition for creator'
     end
 
-    composition.map = map if map
+    if map
+      composition.map = map
+      composition.slug = nil # will get regenerated based on map
+    end
+
+    if (name = data[:name]).present?
+      composition.name = name
+      composition.slug = nil # will get regenerated based on name
+    end
+
+    if (notes = data[:notes]).present?
+      composition.notes = notes
+    end
+
     composition
   end
 

--- a/spec/controllers/compositions_controller_spec.rb
+++ b/spec/controllers/compositions_controller_spec.rb
@@ -109,6 +109,22 @@ RSpec.describe CompositionsController do
       expect(response).to be_success
     end
 
+    it 'creates composition with name and notes' do
+      expect do
+        post :save, params: {
+          name: 'My Sweet Dive Comp', notes: 'o boy', map_id: @map.id,
+          format: :json
+        }
+      end.to change { @anon_user.compositions.count }.by(1)
+      expect(response).to be_success
+
+      composition = @anon_user.compositions.last
+      expect(composition.name).to eq('My Sweet Dive Comp')
+      expect(composition.notes).to eq('o boy')
+      expect(composition.map).to eq(@map)
+      expect(composition.session_id).to eq('8675309')
+    end
+
     it 'updates existing player selection for authenticated user' do
       sign_in @user
 


### PR DESCRIPTION
This hooks up the name field so that the user can rename their composition. It also makes sure the `slug` gets updated so that the URL to view a composition reflects the map and name the comp has.

<img width="464" alt="overwatchteamcomps" src="https://cloud.githubusercontent.com/assets/82317/24083077/9bb2ab7c-0c9e-11e7-8ff1-9fc55bf5d231.png">

This also fixes a bug where the 'share' link would be visible before the composition had been saved, meaning the link wouldn't work. Now the link just isn't visible before you've saved the composition.

This also refactors some React components to not pass around complex object props or state where possible, instead favoring simple types like strings and numbers. This makes the requirements of a component more explicit, so you can see exactly which parts are necessary to render it.

This branch helps with #86 a little by shortening 'Choose a player' to 'Player' and 'Choose a hero' to 'Hero.' It's my hope that the purpose of these select menus is still obvious even with shorter names.