### PR TITLE
Add map segment status bars, player count

### DIFF
--- a/app/assets/javascripts/components/anon-layout.jsx
+++ b/app/assets/javascripts/components/anon-layout.jsx
@@ -1,11 +1,18 @@
 import Footer from './footer.jsx'
 
 const AnonLayout = function(props) {
+  const path = props.location.pathname
   return (
     <div className="layout-container">
       <div className="container">
         <nav className="nav">
           <div className="nav-right">
+            {path === '/about' ? (
+              <a
+                href="/"
+                className="nav-item"
+              >Team composition</a>
+            ) : ''}
             <a
               href="/users/auth/bnet"
               className="nav-item"
@@ -22,7 +29,8 @@ const AnonLayout = function(props) {
 }
 
 AnonLayout.propTypes = {
-  children: React.PropTypes.object.isRequired
+  children: React.PropTypes.object.isRequired,
+  location: React.PropTypes.object.isRequired
 }
 
 export default AnonLayout

--- a/app/assets/javascripts/components/app.jsx
+++ b/app/assets/javascripts/components/app.jsx
@@ -34,8 +34,8 @@ function redirectIfSignedIn(nextState, replace, callback) {
         pathname: '/user',
         state: { nextPathname: nextState.location.pathname }
       })
-      callback()
     }
+    callback()
   } else {
     const api = new OverwatchTeamCompsApi()
     api.getUser().then(json => {

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -149,7 +149,11 @@ export default class CompositionForm extends React.Component {
                 {mapSegments.map((segment, i) => (
                   <MapSegmentHeader
                     key={segment.id}
-                    mapSegment={segment.name}
+                    name={segment.name}
+                    filled={segment.filled}
+                    isAttack={segment.isAttack}
+                    isFirstOfKind={segment.isFirstOfKind}
+                    isLastOfKind={segment.isLastOfKind}
                     index={i}
                   />
                 ))}

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -134,6 +134,8 @@ export default class CompositionForm extends React.Component {
       return <p className="container">Loading...</p>
     }
 
+    const selectedPlayerCount = composition.players.
+      filter(p => typeof p.id === 'number').length
     const mapSegments = composition.map.segments
     return (
       <form className="composition-form">
@@ -145,7 +147,10 @@ export default class CompositionForm extends React.Component {
           <table className="players-table">
             <thead>
               <tr>
-                <th className="players-header" />
+                <th className="players-header">
+                  <span className="player-count">{selectedPlayerCount} / 6</span>
+                  Team
+                </th>
                 {mapSegments.map((segment, i) => (
                   <MapSegmentHeader
                     key={segment.id}

--- a/app/assets/javascripts/components/edit-player-selection-row.jsx
+++ b/app/assets/javascripts/components/edit-player-selection-row.jsx
@@ -26,6 +26,7 @@ const EditPlayerSelectionRow = function(props) {
             disabled={typeof selectedPlayer.id !== 'number'}
             selectedHeroID={selections[segment.id]}
             onChange={heroID => onHeroSelection(heroID, segment.id)}
+            selectID={`${inputID}_segment_${segment.id}`}
           />
         </td>
       ))}

--- a/app/assets/javascripts/components/hero-select.jsx
+++ b/app/assets/javascripts/components/hero-select.jsx
@@ -21,8 +21,9 @@ class HeroSelect extends React.Component {
 
   render() {
     const { heroes, selectedHeroID, disabled } = this.props
+    const isFilled = typeof selectedHeroID === 'number'
     return (
-      <div className="hero-select-container">
+      <div className={`hero-select-container ${isFilled ? '' : 'not-filled'}`}>
         {this.heroPortrait()}
         <span className="select">
           <select

--- a/app/assets/javascripts/components/hero-select.jsx
+++ b/app/assets/javascripts/components/hero-select.jsx
@@ -20,16 +20,19 @@ class HeroSelect extends React.Component {
   }
 
   render() {
-    const { heroes, selectedHeroID, disabled } = this.props
+    const { heroes, selectedHeroID, disabled, selectID } = this.props
     const isFilled = typeof selectedHeroID === 'number'
     return (
       <div className={`hero-select-container ${isFilled ? '' : 'not-filled'}`}>
-        {this.heroPortrait()}
+        <label
+          htmlFor={selectID}
+        >{this.heroPortrait()}</label>
         <span className="select">
           <select
             onChange={e => this.onChange(e)}
             value={selectedHeroID || ''}
             disabled={disabled}
+            id={selectID}
           >
             <option>Choose a hero</option>
             {heroes.map(hero => (
@@ -49,7 +52,8 @@ HeroSelect.propTypes = {
   heroes: React.PropTypes.array.isRequired,
   onChange: React.PropTypes.func.isRequired,
   selectedHeroID: React.PropTypes.number,
-  disabled: React.PropTypes.bool.isRequired
+  disabled: React.PropTypes.bool.isRequired,
+  selectID: React.PropTypes.string.isRequired
 }
 
 export default HeroSelect

--- a/app/assets/javascripts/components/hero-select.jsx
+++ b/app/assets/javascripts/components/hero-select.jsx
@@ -22,7 +22,7 @@ class HeroSelect extends React.Component {
   render() {
     const { heroes, selectedHeroID, disabled } = this.props
     return (
-      <div>
+      <div className="hero-select-container">
         {this.heroPortrait()}
         <span className="select">
           <select

--- a/app/assets/javascripts/components/map-segment-header.jsx
+++ b/app/assets/javascripts/components/map-segment-header.jsx
@@ -1,10 +1,10 @@
 class MapSegmentHeader extends React.Component {
   className() {
-    const { mapSegment, index } = this.props
+    const { index, isAttack } = this.props
     const columnClass = index % 2 === 0 ? 'even-column' : 'odd-column'
     const classes = [columnClass]
 
-    if (mapSegment.toLowerCase().indexOf('attack') > -1) {
+    if (isAttack) {
       classes.push('text-attack')
     } else {
       classes.push('text-defend')
@@ -13,13 +13,44 @@ class MapSegmentHeader extends React.Component {
     return classes.join(' ')
   }
 
+  filledStatusBar() {
+    const { filled, isFirstOfKind, isAttack, isLastOfKind } = this.props
+    const classes = ['map-segment-filled-status']
+    if (isFirstOfKind) {
+      classes.push('is-first')
+    }
+    if (isLastOfKind) {
+      classes.push('is-last')
+    }
+    if (filled) {
+      classes.push('is-filled')
+    } else {
+      classes.push('is-not-filled')
+    }
+    if (isAttack) {
+      classes.push('attacking')
+    } else {
+      classes.push('defending')
+    }
+    return <div className={classes.join(' ')} />
+  }
+
   render() {
-    return <th className={this.className()}>{this.props.mapSegment}</th>
+    return (
+      <th className={this.className()}>
+        {this.props.name}
+        {this.filledStatusBar()}
+      </th>
+    )
   }
 }
 
 MapSegmentHeader.propTypes = {
-  mapSegment: React.PropTypes.string.isRequired,
+  name: React.PropTypes.string.isRequired,
+  filled: React.PropTypes.bool.isRequired,
+  isAttack: React.PropTypes.bool.isRequired,
+  isFirstOfKind: React.PropTypes.bool.isRequired,
+  isLastOfKind: React.PropTypes.bool.isRequired,
   index: React.PropTypes.number.isRequired
 }
 

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -80,7 +80,7 @@ class PlayerSelect extends React.Component {
   render() {
     const { inputID, label } = this.props
     return (
-      <div>
+      <div className="player-select-container">
         <label
           htmlFor={inputID}
           className="label"

--- a/app/assets/stylesheets/colors.scss
+++ b/app/assets/stylesheets/colors.scss
@@ -8,8 +8,10 @@ $transparent-dark: rgba(0, 0, 0, 0.6);
 
 // UI Colors
 $attack: #BA182C;
+$light-attack: #f0dddf;
 $mix: #645398;
 $defend: #0E9ED2;
+$light-defend: #deeff8;
 $block: #111318;
 $form: #F6F6F7;
 

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -57,24 +57,49 @@
 .players-table {
   width: 100%;
 
-  .odd-column {
+  .odd-column .hero-select-container {
     background-color: #fbfbfb;
+  }
+
+  .players-header,
+  .player-cell {
+    padding-right: 2em;
   }
 
   .players-header {
     text-transform: uppercase;
     color: #727783;
+
+    .player-count {
+      float: right;
+    }
   }
 
   .hero-select-cell {
     color: #292b31;
+    white-space: nowrap;
+  }
+
+  .hero-select-container {
+    border: 2px solid #f2f3f4;
+    margin-right: 4px;
+    margin-bottom: 9px;
+    @include border-radius(4px);
+    @include display-flex;
+    @include align-items(center);
   }
 
   .player-cell {
-    background-color: #f5f5f6;
     color: #292b31;
     white-space: nowrap;
-    padding-right: 0.5em;
+  }
+
+  .player-select-container {
+    background-color: #f5f5f6;
+
+    .label {
+      color: #c8cace;
+    }
   }
 
   tbody td {
@@ -100,9 +125,9 @@
   .hero-portrait-placeholder,
   .hero-portrait {
     display: inline-block;
-    width: 40px;
-    @include border-radius(3px);
-    padding-left: 5px;
+    width: 35px;
+    @include border-radius(35px);
+    padding-left: 10px;
   }
 
   .hero-portrait-placeholder {

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -46,6 +46,9 @@
 
   thead th {
     padding: 0 0 15px;
+    font-size: 14px;
+    text-transform: uppercase;
+    font-weight: 700;
   }
 }
 

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -1,3 +1,40 @@
+.map-segment-filled-status {
+  display: block;
+  width: 100%;
+  height: 6px;
+  margin-top: 10px;
+
+  &.is-first {
+    @include border-top-left-radius(6px);
+    @include border-bottom-left-radius(6px);
+  }
+
+  &.is-last {
+    @include border-top-right-radius(6px);
+    @include border-bottom-right-radius(6px);
+  }
+
+  &.attacking {
+    &.is-filled {
+      background-color: $attack;
+    }
+
+    &.is-not-filled {
+      background-color: $light-attack;
+    }
+  }
+
+  &.defending {
+    &.is-filled {
+      background-color: $defend;
+    }
+
+    &.is-not-filled {
+      background-color: $light-defend;
+    }
+  }
+}
+
 .composition-header {
   padding: 40px 0;
   margin-bottom: 35px;
@@ -45,8 +82,9 @@
   }
 
   thead th {
-    padding: 0 0 15px;
-    font-size: 14px;
+    padding: 0 3px 15px 3px;
+    text-align: left;
+    font-size: 13px;
     text-transform: uppercase;
     font-weight: 700;
   }

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -81,12 +81,17 @@
   }
 
   .hero-select-container {
-    border: 2px solid #f2f3f4;
+    border: 2px solid #f5f5f6;
     margin-right: 4px;
     margin-bottom: 9px;
+    padding-left: 10px;
     @include border-radius(4px);
     @include display-flex;
     @include align-items(center);
+
+    &.not-filled {
+      background-color: #f5f5f6;
+    }
   }
 
   .player-cell {
@@ -125,13 +130,13 @@
   .hero-portrait-placeholder,
   .hero-portrait {
     display: inline-block;
-    width: 35px;
-    @include border-radius(35px);
-    padding-left: 10px;
+    width: 30px;
+    @include border-radius(30px);
   }
 
   .hero-portrait-placeholder {
-    background-color: #ddd;
+    background-color: #d8d8d8;
+    height: 30px;
   }
 
   .player-cell {

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -59,29 +59,28 @@
 .textarea {
   -moz-appearance: none;
   -webkit-appearance: none;
-  border-radius: 3px;
+  @include border-radius(4px);
   display: block;
   font-size: 1rem;
   height: 2.285em;
   @include justify-content(flex-start);
-  line-height: 1.5;
-  padding-left: 0.75em;
-  padding-right: 0.75em;
+  padding: 10px 0.75em;
   position: relative;
   vertical-align: top;
-  background-color: $white;
-  border: 1px solid #dbdbdb;
+  background-color: #f6f6f7;
+  border: 1px solid #f6f6f7;
   color: $text;
-  box-shadow: inset 0 1px 2px rgba(10, 10, 10, 0.1);
   max-width: 100%;
+  max-height: 600px;
   width: 100%;
   line-height: 1.25;
-  max-height: 600px;
-  max-width: 100%;
   min-height: 120px;
   min-width: 100%;
-  padding: 10px;
   resize: vertical;
+
+  &:focus {
+    box-shadow: inset 0 1px 2px rgba(10, 10, 10, 0.1);
+  }
 }
 
 .label {

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -114,7 +114,6 @@
     display: block;
     font-size: 1em;
     outline: none;
-    padding-right: 2.5em;
 
     &:focus, &:active {
       border-bottom-color: #0e9ed2;
@@ -128,7 +127,7 @@
   }
 
   &:after {
-    border: 1px solid #d8d8d8;
+    border: 2px solid #dbdbdb;
     border-right: 0;
     border-top: 0;
     content: " ";

--- a/app/assets/stylesheets/structure.scss
+++ b/app/assets/stylesheets/structure.scss
@@ -21,6 +21,10 @@ section { margin-bottom: 4em; }
 
 
 @media screen and (min-width: 800px) {
+  .container {
+    max-width: 1700px;
+  }
+
   .flex-grid {
     @include display-flex;
     .col { @include flex(1); }

--- a/app/assets/stylesheets/structure.scss
+++ b/app/assets/stylesheets/structure.scss
@@ -5,7 +5,8 @@
 .container {
   position: relative;
   margin: 0 auto;
-  width: 90%;
+  padding-right: 30px;
+  padding-left: 30px;
 }
 
 .flex-grid {
@@ -20,10 +21,6 @@ section { margin-bottom: 4em; }
 
 
 @media screen and (min-width: 800px) {
-  .container {
-    max-width: 1020px;
-  }
-
   .flex-grid {
     @include display-flex;
     .col { @include flex(1); }

--- a/app/assets/stylesheets/structure.scss
+++ b/app/assets/stylesheets/structure.scss
@@ -17,6 +17,7 @@
   margin: 0 auto;
   padding-right: 30px;
   padding-left: 30px;
+  width: 100%;
 }
 
 .footer {

--- a/app/models/composition_form_builder.rb
+++ b/app/models/composition_form_builder.rb
@@ -28,6 +28,31 @@ class CompositionFormBuilder
     @map_segments ||= @composition.map_segments
   end
 
+  # Returns true if the given MapSegment is fully populated with
+  # player+hero assignments.
+  def map_segment_filled?(map_segment)
+    player_selections.
+      select { |ps| ps.map_segment_id == map_segment.id }.size >= 6
+  end
+
+  # Returns true if the given MapSegment is the first one of its type
+  # (attack v. defense) in the list of map segments.
+  def map_segment_is_first_of_kind?(map_segment)
+    index = map_segments.index(map_segment)
+    return true if index == 0
+    prev_map_segment = map_segments[index - 1]
+    prev_map_segment.is_attack? != map_segment.is_attack?
+  end
+
+  # Returns true if the given MapSegment is the last one of its type
+  # (attack v. defense) in the list of map segments.
+  def map_segment_is_last_of_kind?(map_segment)
+    index = map_segments.index(map_segment)
+    return true if index == map_segments.length - 1
+    next_map_segment = map_segments[index + 1]
+    next_map_segment.is_attack? != map_segment.is_attack?
+  end
+
   def player_selections
     @player_selections ||= @composition.player_selections.
       select(:map_segment_id, :position, :player_id, :hero_id).to_a

--- a/app/models/map_segment.rb
+++ b/app/models/map_segment.rb
@@ -3,4 +3,9 @@ class MapSegment < ApplicationRecord
 
   validates :map, :name, presence: true
   validates :map_id, uniqueness: { scope: :name }
+
+  # Returns true if this MapSegment is on attack.
+  def is_attack?
+    name.start_with?('Attack')
+  end
 end

--- a/app/views/compositions/show.json.jbuilder
+++ b/app/views/compositions/show.json.jbuilder
@@ -17,6 +17,10 @@ json.composition do
     json.segments @composition.map.segments do |map_segment|
       json.id map_segment.id
       json.name map_segment.name
+      json.filled @builder.map_segment_filled?(map_segment)
+      json.isAttack map_segment.is_attack?
+      json.isFirstOfKind @builder.map_segment_is_first_of_kind?(map_segment)
+      json.isLastOfKind @builder.map_segment_is_last_of_kind?(map_segment)
     end
   end
   json.availablePlayers @available_players do |player|


### PR DESCRIPTION
This branch brings us closer to @smbriones' [mockup](https://raw.githubusercontent.com/cheshire137/overwatch-team-comps/master/readme%20screens%20-%20team%20comp%20form%2001.png) by adding a count of how many players have been selected to the left column, and adding status bars for each map segment to indicate if the segment has been fully filled out with heroes.

<img width="1142" alt="overwatchteamcomps" src="https://cloud.githubusercontent.com/assets/82317/24086214/9da6a290-0cd9-11e7-9dc2-e94b53498ad2.png">

The select menus look a little awkward right now with the text almost touching the little arrow on the right, but that should be fixed when #88 lands since it shortens the 'choose a X' text.

This also helps a little with #86 by widening the `.container` class.