### PR TITLE
Couple more style fixes, including colors on show page

### DIFF
--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -179,7 +179,7 @@ export default class CompositionForm extends React.Component {
           <table className="players-table">
             <thead>
               <tr>
-                <th className="players-header">
+                <th className="players-header small-fat-header">
                   <span className="player-count">{selectedPlayerCount} / 6</span>
                   Team
                 </th>
@@ -227,9 +227,10 @@ export default class CompositionForm extends React.Component {
             </tbody>
           </table>
           <div className="composition-notes-wrapper">
-            <label htmlFor="composition_notes">
-              Notes:
-            </label>
+            <label
+              htmlFor="composition_notes"
+              className="label notes-label small-fat-header"
+            >Notes</label>
             <textarea
               id="composition_notes"
               className="textarea"

--- a/app/assets/javascripts/components/composition-view.jsx
+++ b/app/assets/javascripts/components/composition-view.jsx
@@ -25,6 +25,7 @@ class CompositionView extends React.Component {
       updatedAt: null,
       name: null,
       mapName: null,
+      mapSlug: null,
       players: [],
       selections: {},
       heroes: {}
@@ -49,7 +50,8 @@ class CompositionView extends React.Component {
       mapName: composition.map.name,
       players: composition.players,
       selections: composition.selections,
-      heroes: composition.heroes
+      heroes: composition.heroes,
+      mapSlug: composition.map.slug
     })
   }
 
@@ -78,7 +80,7 @@ class CompositionView extends React.Component {
 
   render() {
     const { mapName, mapSegments, name, players, selections,
-            heroes, notes } = this.state
+            heroes, notes, mapSlug } = this.state
 
     if (typeof mapName === 'undefined') {
       return <p className="container">Loading...</p>
@@ -86,7 +88,7 @@ class CompositionView extends React.Component {
 
     return (
       <div>
-        <header className="composition-header">
+        <header className={`composition-header gradient-${mapSlug}`}>
           <div className="container">
             <div className="map-photo-container" />
             <div className="composition-meta">
@@ -111,7 +113,11 @@ class CompositionView extends React.Component {
                 {mapSegments.map((segment, i) => (
                   <MapSegmentHeader
                     key={segment.id}
-                    mapSegment={segment.name}
+                    name={segment.name}
+                    filled={segment.filled}
+                    isAttack={segment.isAttack}
+                    isFirstOfKind={segment.isFirstOfKind}
+                    isLastOfKind={segment.isLastOfKind}
                     index={i}
                   />
                 ))}

--- a/app/assets/javascripts/components/map-segment-header.jsx
+++ b/app/assets/javascripts/components/map-segment-header.jsx
@@ -2,7 +2,7 @@ class MapSegmentHeader extends React.Component {
   className() {
     const { index, isAttack } = this.props
     const columnClass = index % 2 === 0 ? 'even-column' : 'odd-column'
-    const classes = [columnClass]
+    const classes = [columnClass, 'small-fat-header']
 
     if (isAttack) {
       classes.push('text-attack')

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -75,23 +75,45 @@
     }
   }
 
+  .player-cell,
   .hero-select-cell {
-    color: #292b31;
-    white-space: nowrap;
     padding-top: 1px;
   }
 
-  .hero-select-container {
+  .hero-select-cell {
+    color: #292b31;
+    white-space: nowrap;
+  }
+
+  .hero-select-container,
+  .player-select-container {
     border: 2px solid #f5f5f6;
-    margin-right: 4px;
     margin-bottom: 9px;
-    padding-left: 10px;
     @include border-radius(4px);
+  }
+
+  .hero-select-container {
+    margin-right: 4px;
+    padding-left: 10px;
     @include display-flex;
     @include align-items(center);
 
     &.not-filled {
       background-color: #f5f5f6;
+    }
+
+    label,
+    .select {
+      display: table-cell;
+      vertical-align: middle;
+    }
+
+    .select {
+      width: 100%;
+
+      select {
+        width: 100%;
+      }
     }
   }
 
@@ -103,8 +125,24 @@
   .player-select-container {
     background-color: #f5f5f6;
 
+    .label,
+    .player-select.select {
+      display: table-cell;
+      vertical-align: middle;
+    }
+
     .label {
       color: #c8cace;
+    }
+
+    .player-select.select {
+      width: 100%;
+
+      select {
+        padding-left: 0.25em;
+        padding-right: 0;
+        width: 100%;
+      }
     }
   }
 
@@ -146,11 +184,6 @@
       font-size: 1rem;
       padding-left: 15px;
       margin-right: 0.5em;
-    }
-
-    .select select {
-      padding-left: 0.25em;
-      padding-right: 0;
     }
 
     .input {

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -2,7 +2,7 @@
   display: block;
   width: 100%;
   height: 6px;
-  margin-top: 10px;
+  margin-top: 9px;
 
   &.is-first {
     @include border-top-left-radius(6px);
@@ -67,11 +67,11 @@
   }
 
   .players-header {
-    text-transform: uppercase;
     color: #727783;
 
     .player-count {
       float: right;
+      margin-right: 6px;
     }
   }
 
@@ -152,15 +152,16 @@
 
   thead th {
     text-align: left;
-    font-size: 13px;
-    text-transform: uppercase;
-    font-weight: 700;
-    padding: 0.5em 20px;
+    padding: 0 4px 9px 0;
   }
 }
 
 .composition-notes-wrapper {
   margin-top: 60px;
+
+  .notes-label {
+    margin-bottom: 9px;
+  }
 }
 
 .composition-form {

--- a/app/assets/stylesheets/typography.scss
+++ b/app/assets/stylesheets/typography.scss
@@ -46,3 +46,10 @@ h4 {
   letter-spacing: 1px;
   margin: 1em 0;
 }
+
+.small-fat-header {
+  text-transform: uppercase;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 1px;
+}


### PR DESCRIPTION
This branch:

- Makes sure the new map gradients show up on the composition view page, not just the composition form.
- Makes the hero select and player select fill the available width.
- Styles the 'notes' label like in [the mockup](https://raw.githubusercontent.com/cheshire137/overwatch-team-comps/master/readme%20screens%20-%20team%20comp%20form%2001.png).
- Adjusts the alignment of player and hero columns so they line up.