### PR TITLE
Allow editing and deleting players

### DIFF
--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -154,6 +154,10 @@ export default class CompositionForm extends React.Component {
       catch(err => CompositionForm.onCompositionSaveError(err))
   }
 
+  editPlayer(playerID) {
+    console.log('edit', playerID)
+  }
+
   render() {
     const { name, slug, mapID, mapSegments, players, heroes,
             selections, notes, mapSlug } = this.state
@@ -220,6 +224,7 @@ export default class CompositionForm extends React.Component {
                     onPlayerSelection={(playerID, newName) =>
                       this.onPlayerSelected(playerID, newName, index)
                     }
+                    editPlayer={playerID => this.editPlayer(playerID)}
                   />
                 )
               })}

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -161,9 +161,16 @@ export default class CompositionForm extends React.Component {
     this.setState({ editingPlayerID: playerID })
   }
 
+  closePlayerEditModal(newComposition) {
+    this.editPlayer(null)
+    if (newComposition) {
+      this.onCompositionLoaded(newComposition)
+    }
+  }
+
   render() {
     const { name, slug, mapID, mapSegments, players, heroes,
-            selections, notes, mapSlug, editingPlayerID } = this.state
+            selections, notes, mapSlug, editingPlayerID, id } = this.state
 
     if (typeof mapID !== 'number') {
       return <p className="container">Loading...</p>
@@ -260,7 +267,9 @@ export default class CompositionForm extends React.Component {
         <PlayerEditModal
           playerID={editingPlayerID}
           playerName={editingPlayer ? editingPlayer.name : ''}
-          close={() => this.editPlayer(null)}
+          battletag={editingPlayer ? editingPlayer.battletag : ''}
+          close={newComp => this.closePlayerEditModal(newComp)}
+          compositionID={id}
           isOpen={typeof editingPlayerID === 'number'}
         />
       </form>

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -171,6 +171,9 @@ export default class CompositionForm extends React.Component {
 
     const selectedPlayerCount = players.
       filter(p => typeof p.id === 'number').length
+    const editingPlayer = typeof editingPlayerID === 'number'
+      ? players.filter(p => p.id === editingPlayerID)[0]
+      : null
 
     return (
       <form className="composition-form">
@@ -256,6 +259,7 @@ export default class CompositionForm extends React.Component {
         </div>
         <PlayerEditModal
           playerID={editingPlayerID}
+          playerName={editingPlayer ? editingPlayer.name : ''}
           close={() => this.editPlayer(null)}
           isOpen={typeof editingPlayerID === 'number'}
         />

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -1,6 +1,8 @@
 import CompositionFormHeader from './composition-form-header.jsx'
 import EditPlayerSelectionRow from './edit-player-selection-row.jsx'
 import MapSegmentHeader from './map-segment-header.jsx'
+import PlayerEditModal from './player-edit-modal.jsx'
+
 import OverwatchTeamCompsApi from '../models/overwatch-team-comps-api'
 
 export default class CompositionForm extends React.Component {
@@ -29,7 +31,8 @@ export default class CompositionForm extends React.Component {
       availablePlayers: [],
       heroes: {},
       selections: {},
-      notes: ''
+      notes: '',
+      editingPlayerID: null
     }
   }
 
@@ -155,7 +158,22 @@ export default class CompositionForm extends React.Component {
   }
 
   editPlayer(playerID) {
-    console.log('edit', playerID)
+    this.setState({ editingPlayerID: playerID })
+  }
+
+  playerEditModal() {
+    const { editingPlayerID } = this.state
+
+    if (typeof editingPlayerID !== 'number') {
+      return null
+    }
+
+    return (
+      <PlayerEditModal
+        playerID={editingPlayerID}
+        close={() => this.editPlayer(null)}
+      />
+    )
   }
 
   render() {
@@ -251,6 +269,7 @@ export default class CompositionForm extends React.Component {
             </p>
           </div>
         </div>
+        {this.playerEditModal()}
       </form>
     )
   }

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -209,7 +209,6 @@ export default class CompositionForm extends React.Component {
                     key={key}
                     inputID={inputID}
                     playerID={player.id}
-                    playerName={player.name}
                     players={selectablePlayers}
                     heroes={playerHeroes}
                     selections={playerSelections}

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -161,24 +161,9 @@ export default class CompositionForm extends React.Component {
     this.setState({ editingPlayerID: playerID })
   }
 
-  playerEditModal() {
-    const { editingPlayerID } = this.state
-
-    if (typeof editingPlayerID !== 'number') {
-      return null
-    }
-
-    return (
-      <PlayerEditModal
-        playerID={editingPlayerID}
-        close={() => this.editPlayer(null)}
-      />
-    )
-  }
-
   render() {
     const { name, slug, mapID, mapSegments, players, heroes,
-            selections, notes, mapSlug } = this.state
+            selections, notes, mapSlug, editingPlayerID } = this.state
 
     if (typeof mapID !== 'number') {
       return <p className="container">Loading...</p>
@@ -269,7 +254,11 @@ export default class CompositionForm extends React.Component {
             </p>
           </div>
         </div>
-        {this.playerEditModal()}
+        <PlayerEditModal
+          playerID={editingPlayerID}
+          close={() => this.editPlayer(null)}
+          isOpen={typeof editingPlayerID === 'number'}
+        />
       </form>
     )
   }

--- a/app/assets/javascripts/components/edit-player-selection-row.jsx
+++ b/app/assets/javascripts/components/edit-player-selection-row.jsx
@@ -4,7 +4,7 @@ import PlayerSelect from './player-select.jsx'
 const EditPlayerSelectionRow = function(props) {
   const { inputID, playerID, nameLabel, onHeroSelection,
           mapSegments, onPlayerSelection, players, heroes,
-          selections } = props
+          selections, editPlayer } = props
   return (
     <tr>
       <td className="player-cell">
@@ -16,6 +16,7 @@ const EditPlayerSelectionRow = function(props) {
           onChange={(newPlayerID, newName) =>
             onPlayerSelection(newPlayerID, newName)
           }
+          editPlayer={() => editPlayer(playerID)}
         />
       </td>
       {mapSegments.map((segment, i) => (
@@ -45,7 +46,8 @@ EditPlayerSelectionRow.propTypes = {
   onHeroSelection: React.PropTypes.func.isRequired,
   mapSegments: React.PropTypes.array.isRequired,
   heroes: React.PropTypes.array.isRequired,
-  selections: React.PropTypes.object.isRequired
+  selections: React.PropTypes.object.isRequired,
+  editPlayer: React.PropTypes.func.isRequired
 }
 
 export default EditPlayerSelectionRow

--- a/app/assets/javascripts/components/edit-player-selection-row.jsx
+++ b/app/assets/javascripts/components/edit-player-selection-row.jsx
@@ -2,7 +2,7 @@ import HeroSelect from './hero-select.jsx'
 import PlayerSelect from './player-select.jsx'
 
 const EditPlayerSelectionRow = function(props) {
-  const { inputID, playerID, playerName, nameLabel, onHeroSelection,
+  const { inputID, playerID, nameLabel, onHeroSelection,
           mapSegments, onPlayerSelection, players, heroes,
           selections } = props
   return (
@@ -12,7 +12,6 @@ const EditPlayerSelectionRow = function(props) {
           inputID={inputID}
           label={nameLabel}
           playerID={playerID}
-          name={playerName}
           players={players}
           onChange={(newPlayerID, newName) =>
             onPlayerSelection(newPlayerID, newName)
@@ -40,7 +39,6 @@ const EditPlayerSelectionRow = function(props) {
 EditPlayerSelectionRow.propTypes = {
   inputID: React.PropTypes.string.isRequired,
   playerID: React.PropTypes.number,
-  playerName: React.PropTypes.string.isRequired,
   players: React.PropTypes.array.isRequired,
   onPlayerSelection: React.PropTypes.func.isRequired,
   nameLabel: React.PropTypes.string.isRequired,

--- a/app/assets/javascripts/components/player-edit-modal.jsx
+++ b/app/assets/javascripts/components/player-edit-modal.jsx
@@ -1,0 +1,36 @@
+class PlayerEditModal extends React.Component {
+  onClose(event) {
+    event.currentTarget.blur()
+    this.props.close()
+  }
+
+  render() {
+    return (
+      <div>
+        <div className="modal-overlay modal-overlay-active" />
+        <div className="modal">
+          <div className="modal-popup">
+            <div className="modal-content">
+              <h2 className="modal-header">
+                Edit Player
+              </h2>
+            </div>
+            <button
+              type="button"
+              className="modal-close"
+              aria-label="Close modal"
+              onClick={e => this.onClose(e)}
+            ><i className="fa fa-times" aria-hidden="true" /></button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+PlayerEditModal.propTypes = {
+  playerID: React.PropTypes.number.isRequired,
+  close: React.PropTypes.func.isRequired
+}
+
+export default PlayerEditModal

--- a/app/assets/javascripts/components/player-edit-modal.jsx
+++ b/app/assets/javascripts/components/player-edit-modal.jsx
@@ -29,6 +29,12 @@ class PlayerEditModal extends React.Component {
     this.props.close()
   }
 
+  onKeyDown(event) {
+    if (event.keyCode === 27) { // Esc
+      this.props.close()
+    }
+  }
+
   onPlayerNameChange(event) {
     this.setState({ playerName: event.target.value })
   }
@@ -61,6 +67,7 @@ class PlayerEditModal extends React.Component {
               value={playerName || ''}
               onChange={e => this.onPlayerNameChange(e)}
               className="input"
+              onKeyDown={e => this.onKeyDown(e)}
               placeholder="Player name"
               autoFocus
             />
@@ -76,6 +83,7 @@ class PlayerEditModal extends React.Component {
               value={battletag || ''}
               onChange={e => this.onBattletagChange(e)}
               className="input"
+              onKeyDown={e => this.onKeyDown(e)}
               placeholder="Battle.net username"
             />
           </div>

--- a/app/assets/javascripts/components/player-edit-modal.jsx
+++ b/app/assets/javascripts/components/player-edit-modal.jsx
@@ -1,6 +1,10 @@
 import OverwatchTeamCompsApi from '../models/overwatch-team-comps-api'
 
 class PlayerEditModal extends React.Component {
+  static onPlayerDeleteError(error) {
+    console.error('failed to delete player', error)
+  }
+
   static onPlayerUpdateError(error) {
     console.error('failed to update player', error)
   }
@@ -41,7 +45,7 @@ class PlayerEditModal extends React.Component {
     this.setState({ playerName: event.target.value })
   }
 
-  onSaved(composition) {
+  onCompositionLoaded(composition) {
     this.props.close(composition)
   }
 
@@ -75,6 +79,15 @@ class PlayerEditModal extends React.Component {
 
   delete(event) {
     event.currentTarget.blur()
+
+    const { playerID, compositionID } = this.props
+    const api = new OverwatchTeamCompsApi()
+
+    const body = { composition_id: compositionID }
+
+    api.deletePlayer(playerID, body).
+      then(newComp => this.onCompositionLoaded(newComp)).
+      catch(err => PlayerEditModal.onPlayerDeleteError(err))
   }
 
   deleteConfirmation() {
@@ -168,7 +181,7 @@ class PlayerEditModal extends React.Component {
     }
 
     api.updatePlayer(playerID, body).
-      then(newComp => this.onSaved(newComp)).
+      then(newComp => this.onCompositionLoaded(newComp)).
       catch(err => PlayerEditModal.onPlayerUpdateError(err))
   }
 

--- a/app/assets/javascripts/components/player-edit-modal.jsx
+++ b/app/assets/javascripts/components/player-edit-modal.jsx
@@ -9,14 +9,16 @@ class PlayerEditModal extends React.Component {
     super(props)
     this.state = {
       playerName: props.playerName,
-      battletag: props.battletag
+      battletag: props.battletag,
+      showDeleteConfirmation: false
     }
   }
 
   componentWillReceiveProps(nextProps) {
     this.setState({
       playerName: nextProps.playerName,
-      battletag: nextProps.battletag
+      battletag: nextProps.battletag,
+      showDeleteConfirmation: false
     })
   }
 
@@ -43,69 +45,112 @@ class PlayerEditModal extends React.Component {
     this.props.close(composition)
   }
 
+  cancelDelete(event) {
+    event.currentTarget.blur()
+    this.setState({ showDeleteConfirmation: false })
+  }
+
+  confirmDelete(event) {
+    event.currentTarget.blur()
+    this.setState({ showDeleteConfirmation: true })
+  }
+
   contents() {
-    const { isOpen } = this.props
-    if (!isOpen) {
+    if (!this.props.isOpen) {
       return null
     }
 
-    const { playerName, battletag } = this.state
     return (
       <div className="modal-popup">
-        <div className="modal-content">
-          <h2 className="modal-header">
-            Edit Player
-          </h2>
-          <div className="field">
-            <label
-              className="label"
-              htmlFor="edit_player_name"
-            >Name:</label>
-            <input
-              type="text"
-              id="edit_player_name"
-              value={playerName || ''}
-              onChange={e => this.onPlayerNameChange(e)}
-              className="input"
-              onKeyDown={e => this.onKeyDown(e)}
-              placeholder="Player name"
-              autoFocus
-            />
-          </div>
-          <div className="field">
-            <label
-              className="label"
-              htmlFor="edit_player_battletag"
-            >Battletag:</label>
-            <input
-              type="text"
-              id="edit_player_battletag"
-              value={battletag || ''}
-              onChange={e => this.onBattletagChange(e)}
-              className="input"
-              onKeyDown={e => this.onKeyDown(e)}
-              placeholder="Battle.net username"
-            />
-          </div>
-          <div className="clearfix">
-            <button
-              type="button"
-              className="delete-player-button button-link"
-              onClick={e => this.delete(e)}
-            ><i className="fa fa-trash" aria-hidden="true"></i> Delete player</button>
-            <button
-              type="button"
-              className="button is-primary"
-              onClick={e => this.save(e)}
-            >Save</button>
-          </div>
-        </div>
+        {this.state.showDeleteConfirmation ? this.deleteConfirmation() : this.editFields()}
         <button
           type="button"
           className="modal-close"
           aria-label="Close modal"
           onClick={e => this.onClose(e)}
         ><i className="fa fa-times" aria-hidden="true" /></button>
+      </div>
+    )
+  }
+
+  delete(event) {
+    event.currentTarget.blur()
+  }
+
+  deleteConfirmation() {
+    const { playerName } = this.props
+    return (
+      <div className="modal-content">
+        <h2 className="modal-header">
+          Confirm Delete Player
+        </h2>
+        <p>
+          Are you sure you want to delete <strong>{playerName}</strong>?
+        </p>
+        <button
+          type="button"
+          className="button is-danger"
+          onClick={e => this.delete(e)}
+        >Yes, delete</button>
+        <button
+          type="button"
+          className="button is-normal"
+          onClick={e => this.cancelDelete(e)}
+        >No, do not delete</button>
+      </div>
+    )
+  }
+
+  editFields() {
+    const { playerName, battletag } = this.state
+    return (
+      <div className="modal-content">
+        <h2 className="modal-header">
+          Edit Player
+        </h2>
+        <div className="field">
+          <label
+            className="label"
+            htmlFor="edit_player_name"
+          >Name:</label>
+          <input
+            type="text"
+            id="edit_player_name"
+            value={playerName || ''}
+            onChange={e => this.onPlayerNameChange(e)}
+            className="input"
+            onKeyDown={e => this.onKeyDown(e)}
+            placeholder="Player name"
+            autoFocus
+          />
+        </div>
+        <div className="field">
+          <label
+            className="label"
+            htmlFor="edit_player_battletag"
+          >Battletag:</label>
+          <input
+            type="text"
+            id="edit_player_battletag"
+            value={battletag || ''}
+            onChange={e => this.onBattletagChange(e)}
+            className="input"
+            onKeyDown={e => this.onKeyDown(e)}
+            placeholder="Battle.net username"
+          />
+        </div>
+        <div className="clearfix">
+          <button
+            type="button"
+            className="delete-player-button button-link"
+            onClick={e => this.confirmDelete(e)}
+          ><i className="fa fa-trash" aria-hidden="true" /> Delete player</button>
+          <button
+            type="button"
+            className="button is-primary"
+            onClick={e => this.save(e)}
+          >Save</button>
+        </div>
       </div>
     )
   }

--- a/app/assets/javascripts/components/player-edit-modal.jsx
+++ b/app/assets/javascripts/components/player-edit-modal.jsx
@@ -87,11 +87,18 @@ class PlayerEditModal extends React.Component {
               placeholder="Battle.net username"
             />
           </div>
-          <button
-            type="button"
-            className="button is-primary"
-            onClick={e => this.save(e)}
-          >Save</button>
+          <div className="clearfix">
+            <button
+              type="button"
+              className="delete-player-button button-link"
+              onClick={e => this.delete(e)}
+            ><i className="fa fa-trash" aria-hidden="true"></i> Delete player</button>
+            <button
+              type="button"
+              className="button is-primary"
+              onClick={e => this.save(e)}
+            >Save</button>
+          </div>
         </div>
         <button
           type="button"

--- a/app/assets/javascripts/components/player-edit-modal.jsx
+++ b/app/assets/javascripts/components/player-edit-modal.jsx
@@ -1,7 +1,67 @@
 class PlayerEditModal extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { playerName: props.playerName }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({ playerName: nextProps.playerName })
+  }
+
   onClose(event) {
     event.currentTarget.blur()
     this.props.close()
+  }
+
+  onPlayerNameChange(event) {
+    this.setState({ playerName: event.target.value })
+  }
+
+  contents() {
+    const { isOpen } = this.props
+    if (!isOpen) {
+      return null
+    }
+
+    const { playerName } = this.state
+    return (
+      <div className="modal-popup">
+        <div className="modal-content">
+          <h2 className="modal-header">
+            Edit Player
+          </h2>
+          <div className="field">
+            <label
+              className="label"
+              htmlFor="edit_player_name"
+            >Name:</label>
+            <input
+              type="text"
+              id="edit_player_name"
+              value={playerName}
+              onChange={e => this.onPlayerNameChange(e)}
+              className="input"
+              autoFocus
+            />
+          </div>
+          <button
+            type="button"
+            className="button is-primary"
+            onClick={e => this.save(e)}
+          >Save</button>
+        </div>
+        <button
+          type="button"
+          className="modal-close"
+          aria-label="Close modal"
+          onClick={e => this.onClose(e)}
+        ><i className="fa fa-times" aria-hidden="true" /></button>
+      </div>
+    )
+  }
+
+  save(event) {
+    event.currentTarget.blur()
   }
 
   render() {
@@ -10,19 +70,7 @@ class PlayerEditModal extends React.Component {
       <div>
         <div className={`modal-overlay modal-overlay-${isOpen ? 'active' : 'hide'}`} />
         <div className="modal" style={{ display: isOpen ? 'block' : 'none' }}>
-          <div className="modal-popup">
-            <div className="modal-content">
-              <h2 className="modal-header">
-                Edit Player
-              </h2>
-            </div>
-            <button
-              type="button"
-              className="modal-close"
-              aria-label="Close modal"
-              onClick={e => this.onClose(e)}
-            ><i className="fa fa-times" aria-hidden="true" /></button>
-          </div>
+          {this.contents()}
         </div>
       </div>
     )
@@ -30,7 +78,8 @@ class PlayerEditModal extends React.Component {
 }
 
 PlayerEditModal.propTypes = {
-  playerID: React.PropTypes.number.isRequired,
+  playerID: React.PropTypes.number,
+  playerName: React.PropTypes.string,
   close: React.PropTypes.func.isRequired,
   isOpen: React.PropTypes.bool.isRequired
 }

--- a/app/assets/javascripts/components/player-edit-modal.jsx
+++ b/app/assets/javascripts/components/player-edit-modal.jsx
@@ -5,10 +5,11 @@ class PlayerEditModal extends React.Component {
   }
 
   render() {
+    const { isOpen } = this.props
     return (
       <div>
-        <div className="modal-overlay modal-overlay-active" />
-        <div className="modal">
+        <div className={`modal-overlay modal-overlay-${isOpen ? 'active' : 'hide'}`} />
+        <div className="modal" style={{ display: isOpen ? 'block' : 'none' }}>
           <div className="modal-popup">
             <div className="modal-content">
               <h2 className="modal-header">
@@ -30,7 +31,8 @@ class PlayerEditModal extends React.Component {
 
 PlayerEditModal.propTypes = {
   playerID: React.PropTypes.number.isRequired,
-  close: React.PropTypes.func.isRequired
+  close: React.PropTypes.func.isRequired,
+  isOpen: React.PropTypes.bool.isRequired
 }
 
 export default PlayerEditModal

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -2,11 +2,7 @@ class PlayerSelect extends React.Component {
   constructor(props) {
     super(props)
 
-    this.state = { name: props.name, showNewNameField: false }
-  }
-
-  componentWillReceiveProps(nextProps) {
-    this.setState({ name: nextProps.name, showNewNameField: false })
+    this.state = { name: '', showNewNameField: false }
   }
 
   onChange(event) {
@@ -15,6 +11,12 @@ class PlayerSelect extends React.Component {
       this.setState({ showNewNameField: true })
     } else {
       this.props.onChange(newPlayerID, null)
+    }
+  }
+
+  onNewNameKeyDown(event) {
+    if (event.keyCode === 27) { // Esc
+      this.setState({ showNewNameField: false })
     }
   }
 
@@ -47,6 +49,7 @@ class PlayerSelect extends React.Component {
             placeholder="Player name"
             value={this.state.name}
             onChange={e => this.onNewNameSet(e)}
+            onKeyDown={e => this.onNewNameKeyDown(e)}
             className="input player-name-input"
             autoFocus
           />

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -24,6 +24,11 @@ class PlayerSelect extends React.Component {
     this.setState({ name: event.target.value })
   }
 
+  editPlayer(event) {
+    event.currentTarget.blur()
+    this.props.editPlayer()
+  }
+
   saveNewName(event) {
     event.preventDefault()
     const name = this.state.name
@@ -64,12 +69,14 @@ class PlayerSelect extends React.Component {
       )
     }
 
+    const isPlayerSelected = typeof playerID === 'number'
+
     return (
       <div className="existing-player-container">
         <span className="select player-select">
           <select
             onChange={e => this.onChange(e)}
-            value={typeof playerID === 'number' ? playerID : ''}
+            value={isPlayerSelected ? playerID : ''}
           >
             <option value="">Player</option>
             {players.map(player => (
@@ -81,10 +88,13 @@ class PlayerSelect extends React.Component {
             <option value="new">Add new player</option>
           </select>
         </span>
-        <button
-          type="button"
-          className="button-link edit-player-button"
-        ><i className="fa fa-cog" aria-hidden="true" /></button>
+        {isPlayerSelected ? (
+          <button
+            type="button"
+            className="button-link edit-player-button"
+            onClick={e => this.editPlayer(e)}
+          ><i className="fa fa-cog" aria-hidden="true" /></button>
+        ) : ''}
       </div>
     )
   }
@@ -108,7 +118,8 @@ PlayerSelect.propTypes = {
   playerID: React.PropTypes.number,
   players: React.PropTypes.array.isRequired,
   onChange: React.PropTypes.func.isRequired,
-  label: React.PropTypes.string.isRequired
+  label: React.PropTypes.string.isRequired,
+  editPlayer: React.PropTypes.func.isRequired
 }
 
 export default PlayerSelect

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -106,7 +106,6 @@ class PlayerSelect extends React.Component {
 PlayerSelect.propTypes = {
   inputID: React.PropTypes.string.isRequired,
   playerID: React.PropTypes.number,
-  name: React.PropTypes.string.isRequired,
   players: React.PropTypes.array.isRequired,
   onChange: React.PropTypes.func.isRequired,
   label: React.PropTypes.string.isRequired

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -47,34 +47,42 @@ class PlayerSelect extends React.Component {
             placeholder="Player name"
             value={this.state.name}
             onChange={e => this.onNewNameSet(e)}
-            className="input"
+            className="input player-name-input"
             autoFocus
           />
-          <button
-            type="button"
-            className="button"
-            onClick={e => this.saveNewName(e)}
-          ><i className="fa fa-check" aria-hidden="true" /></button>
+          <div className="button-wrapper">
+            <button
+              type="button"
+              className="button"
+              onClick={e => this.saveNewName(e)}
+            ><i className="fa fa-check" aria-hidden="true" /></button>
+          </div>
         </div>
       )
     }
 
     return (
-      <span className="select player-select">
-        <select
-          onChange={e => this.onChange(e)}
-          value={typeof playerID === 'number' ? playerID : ''}
-        >
-          <option value="">Player</option>
-          {players.map(player => (
-            <option
-              key={player.id}
-              value={player.id}
-            >{player.name}</option>
-          ))}
-          <option value="new">Add new player</option>
-        </select>
-      </span>
+      <div className="existing-player-container">
+        <span className="select player-select">
+          <select
+            onChange={e => this.onChange(e)}
+            value={typeof playerID === 'number' ? playerID : ''}
+          >
+            <option value="">Player</option>
+            {players.map(player => (
+              <option
+                key={player.id}
+                value={player.id}
+              >{player.name}</option>
+            ))}
+            <option value="new">Add new player</option>
+          </select>
+        </span>
+        <button
+          type="button"
+          className="button-link edit-player-button"
+        ><i className="fa fa-cog" aria-hidden="true" /></button>
+      </div>
     )
   }
 

--- a/app/assets/javascripts/models/fetcher.js
+++ b/app/assets/javascripts/models/fetcher.js
@@ -28,6 +28,10 @@ export default class Fetcher {
     return this.makeRequest('PUT', path, headers, body)
   }
 
+  delete(path, headers, body) {
+    return this.makeRequest('DELETE', path, headers, body)
+  }
+
   makeRequest(method, path, headers, body) {
     const url = `${this.basePath}${path}`
     const data = { method, headers, credentials: 'same-origin' }

--- a/app/assets/javascripts/models/fetcher.js
+++ b/app/assets/javascripts/models/fetcher.js
@@ -24,6 +24,10 @@ export default class Fetcher {
     return this.makeRequest('POST', path, headers, body)
   }
 
+  put(path, headers, body) {
+    return this.makeRequest('PUT', path, headers, body)
+  }
+
   makeRequest(method, path, headers, body) {
     const url = `${this.basePath}${path}`
     const data = { method, headers, credentials: 'same-origin' }

--- a/app/assets/javascripts/models/overwatch-team-comps-api.js
+++ b/app/assets/javascripts/models/overwatch-team-comps-api.js
@@ -59,4 +59,9 @@ export default class OverwatchTeamCompsApi extends Fetcher {
     return this.put(`/players/${id}`, this.defaultHeaders, body).
       then(json => json.composition)
   }
+
+  deletePlayer(id, body) {
+    return this.delete(`/players/${id}`, this.defaultHeaders, body).
+      then(json => json.composition)
+  }
 }

--- a/app/assets/javascripts/models/overwatch-team-comps-api.js
+++ b/app/assets/javascripts/models/overwatch-team-comps-api.js
@@ -54,4 +54,9 @@ export default class OverwatchTeamCompsApi extends Fetcher {
     return this.post('/players', this.defaultHeaders, body).
       then(json => json.composition)
   }
+
+  updatePlayer(id, body) {
+    return this.put(`/players/${id}`, this.defaultHeaders, body).
+      then(json => json.composition)
+  }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,3 +14,4 @@
 @import "composition-form.scss";
 @import "composition-view.scss";
 @import "hero-pool-form.scss";
+@import "player-edit-modal.scss";

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -1,3 +1,15 @@
+.edit-player-button.button-link {
+  color: $soft-header;
+  height: 2.25em;
+  padding-right: 9px;
+
+  &:hover,
+  &:focus {
+    text-decoration: none;
+    color: $attack;
+  }
+}
+
 .map-segment-filled-status {
   display: block;
   width: 100%;
@@ -125,10 +137,23 @@
   .player-select-container {
     background-color: #f5f5f6;
 
+    &,
+    .existing-player-container,
+    .player-new-name-container {
+      display: table;
+      width: 100%;
+    }
+
     .label,
-    .player-select.select {
+    .player-select.select,
+    .edit-player-button {
       display: table-cell;
       vertical-align: middle;
+    }
+
+    .existing-player-container,
+    .player-new-name-container {
+      width: 100%;
     }
 
     .label {
@@ -185,21 +210,6 @@
       font-size: 1rem;
       padding-left: 15px;
       margin-right: 0.5em;
-    }
-
-    .input {
-      padding-left: 0.25em;
-      padding-right: 0.25em;
-      box-shadow: none;
-      border: none;
-      border-bottom: 1px solid transparent;
-      width: auto;
-      margin-right: 2px;
-
-      &:focus,
-      &:active {
-        border-bottom-color: #0e9ed2;
-      }
     }
   }
 }
@@ -266,8 +276,38 @@
 }
 
 .player-new-name-container {
-  display: inline-block;
-  vertical-align: middle;
+  .player-name-input,
+  .button-wrapper {
+    display: table-cell;
+    vertical-align: middle;
+  }
+
+  .player-name-input {
+    padding-left: 0.25em;
+    padding-right: 0.25em;
+    box-shadow: none;
+    border: none;
+    border-bottom: 1px solid transparent;
+    width: 100%;
+    @include border-top-right-radius(0);
+    @include border-bottom-right-radius(0);
+
+    &:focus,
+    &:active {
+      border-bottom-color: $defend;
+    }
+  }
+
+  .button-wrapper {
+    width: 30px;
+    padding-left: 2px;
+
+    .button {
+      height: 2.285em;
+      @include border-top-left-radius(0);
+      @include border-bottom-left-radius(0);
+    }
+  }
 }
 
 .composition-link-container {

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -158,6 +158,7 @@
 
     .label {
       color: #c8cace;
+      width: 34px;
     }
 
     .player-select.select {

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -29,6 +29,16 @@
     box-shadow: 0 0 0.5em rgba(255, 255, 255, 0.25);
     color: $mix;
   }
+
+  &.is-primary {
+    background-color: $defend;
+    border-color: transparent;
+    color: #fff;
+
+    &:hover {
+      background-color: darken($defend, 10%);
+    }
+  }
 }
 
 .button-link {
@@ -164,3 +174,18 @@
   outline: none;
   border-color: $defend;
 }
+
+.field {
+  .label {
+    font-weight: 700;
+
+    &:not(:last-child) {
+      margin-bottom: 0.5em;
+    }
+  }
+
+  &:not(:last-child) {
+    margin-bottom: 0.75rem;
+  }
+}
+

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -31,6 +31,25 @@
   }
 }
 
+.button-link {
+  display: inline-block;
+  padding: 0;
+  font-size: inherit;
+  color: $defend;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  @include user-select(none);
+  background-color: transparent;
+  border: 0;
+  @include appearance(none);
+
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+  }
+}
+
 .input {
   -moz-appearance: none;
   -webkit-appearance: none;

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -30,6 +30,10 @@
     color: $mix;
   }
 
+  &.is-normal {
+    border: 1px solid $form;
+  }
+
   &.is-primary {
     background-color: $defend;
     border-color: transparent;
@@ -37,6 +41,16 @@
 
     &:hover {
       background-color: darken($defend, 10%);
+    }
+  }
+
+  &.is-danger {
+    color: $attack;
+    border: 1px solid $light-attack;
+
+    &:hover {
+      background-color: $light-attack;
+      border-color: lighten($attack, 10%);
     }
   }
 }

--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -1,4 +1,4 @@
-a {
+a, .button-link {
   @include transition-property(color);
   @include transition-duration(0.2s);
   @include transition-timing-function(ease-in-out);

--- a/app/assets/stylesheets/player-edit-modal.scss
+++ b/app/assets/stylesheets/player-edit-modal.scss
@@ -62,3 +62,10 @@
   color: $text;
   @include appearance(none);
 }
+
+.delete-player-button.button-link {
+  float: right;
+  color: $attack;
+  line-height: 36px;
+  font-size: 13px;
+}

--- a/app/assets/stylesheets/player-edit-modal.scss
+++ b/app/assets/stylesheets/player-edit-modal.scss
@@ -1,0 +1,63 @@
+.modal {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding-bottom: 40px;
+}
+
+.modal-popup {
+  position: relative;
+  background-color: $white;
+  background-clip: padding-box;
+  border: 1px solid rgba(27,31,35,0.25);
+  border-radius: 5px;
+  box-shadow: 0 0 18px rgba(27,31,35,0.4);
+}
+
+.modal-content {
+  width: 455px;
+  padding: 15px;
+}
+
+.modal-header {
+  padding: 15px;
+  margin: -15px -15px 15px;
+  font-size: 18px;
+  font-weight: normal;
+  border-bottom: 1px solid $form;
+}
+
+.modal-overlay-active {
+  z-index: 99;
+  background-color: #000;
+  opacity: 0.5;
+}
+
+.modal-overlay-hide {
+  z-index: -100;
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.modal-close {
+  position: absolute;
+  top: 8px;
+  right: 5px;
+  padding: 10px;
+  cursor: pointer;
+  background-color: transparent;
+  border: 0;
+  opacity: 0.25;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  color: $text;
+  @include appearance(none);
+}

--- a/app/assets/stylesheets/player-edit-modal.scss
+++ b/app/assets/stylesheets/player-edit-modal.scss
@@ -19,6 +19,14 @@
 .modal-content {
   width: 456px;
   padding: 15px;
+
+  p {
+    color: $text;
+  }
+
+  .button + .button {
+    margin-left: 1em;
+  }
 }
 
 .modal-header {

--- a/app/assets/stylesheets/player-edit-modal.scss
+++ b/app/assets/stylesheets/player-edit-modal.scss
@@ -1,7 +1,8 @@
 .modal {
   position: absolute;
-  top: 0;
-  left: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   z-index: 100;
   padding-bottom: 40px;
 }
@@ -16,7 +17,7 @@
 }
 
 .modal-content {
-  width: 455px;
+  width: 456px;
   padding: 15px;
 }
 

--- a/app/assets/stylesheets/structure.scss
+++ b/app/assets/stylesheets/structure.scss
@@ -66,3 +66,9 @@ section { margin-bottom: 4em; }
     .col { width: 49%; }
   }
 }
+
+.clearfix:after {
+  content: "";
+  display: table;
+  clear: both;
+}

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -38,9 +38,7 @@ class PlayersController < ApplicationController
   end
 
   def update
-    @composition = Composition.
-      created_by(user: current_user, session_id: session.id).
-      where(id: params[:composition_id]).first
+    @composition = find_composition
     return head :bad_request unless @composition
 
     player = Player.find_if_allowed(params[:id], user: current_user, session_id: session.id)
@@ -59,17 +57,40 @@ class PlayersController < ApplicationController
     end
   end
 
+  def destroy
+    @composition = find_composition
+    return head :bad_request unless @composition
+
+    player = Player.find_if_allowed(params[:id], user: current_user, session_id: session.id)
+    return head :not_found unless player
+
+    if player.destroy
+      @builder = CompositionFormBuilder.new(@composition)
+      @available_players = @composition.
+        available_players(user: current_user, session_id: session.id)
+
+      render template: 'compositions/show'
+    else
+      render json: { error: {
+        player: player.errors.full_messages
+      } }, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def player_params
     params.permit(:name, :battletag)
   end
 
+  def find_composition
+    Composition.created_by(user: current_user, session_id: session.id).
+      where(id: params[:composition_id]).first
+  end
+
   def get_composition
     if params[:composition_id]
-      Composition.
-        created_by(user: current_user, session_id: session.id).
-        where(id: params[:composition_id]).first
+      find_composition
     else
       comp = if user_signed_in?
         Composition.new(user: current_user)

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -37,6 +37,28 @@ class PlayersController < ApplicationController
     render template: 'compositions/show'
   end
 
+  def update
+    @composition = Composition.
+      created_by(user: current_user, session_id: session.id).
+      where(id: params[:composition_id]).first
+    return head :bad_request unless @composition
+
+    player = Player.find_if_allowed(params[:id], user: current_user, session_id: session.id)
+    return head :not_found unless player
+
+    if player.update_attributes(player_params)
+      @builder = CompositionFormBuilder.new(@composition)
+      @available_players = @composition.
+        available_players(user: current_user, session_id: session.id)
+
+      render template: 'compositions/show'
+    else
+      render json: { error: {
+        player: player.errors.full_messages
+      } }, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def player_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,17 @@
 module ApplicationHelper
+  def page_title(path)
+    case path
+    when '/', '/user' then 'Team Composition Form'
+    when '/about', '/user/about' then 'About'
+    when '/user/hero-pool' then 'Your Hero Pool'
+    else
+      if path.start_with?('/comp/')
+        slug = path.split('/comp/').last
+        composition = Composition.where(slug: slug).first
+        if composition
+          "#{composition.name} - #{composition.map.name}"
+        end
+      end
+    end
+  end
 end

--- a/app/models/composition_player.rb
+++ b/app/models/composition_player.rb
@@ -5,6 +5,7 @@ class CompositionPlayer < ApplicationRecord
   has_many :player_selections, dependent: :destroy
 
   before_validation :set_position
+  after_destroy :decrement_positions
 
   validates :player, :composition, :position, presence: true
   validates :position, numericality: { only_integer: true },
@@ -47,5 +48,10 @@ class CompositionPlayer < ApplicationRecord
         errors.add(:player, 'is not valid.')
       end
     end
+  end
+
+  def decrement_positions
+    composition.composition_players.where('position >= ?', position).
+      update_all('position = position - 1')
   end
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -3,6 +3,7 @@ class Player < ApplicationRecord
   belongs_to :creator, class_name: 'User'
 
   has_many :player_heroes, dependent: :destroy
+  has_many :composition_players, dependent: :destroy
 
   validates :name, :creator, presence: true
   validate :creator_session_id_set_if_anonymous

--- a/app/views/compositions/show.json.jbuilder
+++ b/app/views/compositions/show.json.jbuilder
@@ -26,11 +26,13 @@ json.composition do
   json.availablePlayers @available_players do |player|
     json.id player.id
     json.name player.name
+    json.battletag player.battletag
   end
   json.players @builder.rows do |row|
     if row.player
       json.id row.player.id
       json.name row.player.name
+      json.battletag row.player.battletag
     else
       json.name ''
     end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,1 +1,2 @@
+<% content_for(:title_tag) do %><%= page_title(request.path) %><% end %>
 <%= react_component 'App', path: request.path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,9 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>OverwatchTeamComps</title>
+    <title>
+      <%= content_for?(:title_tag) ? content_for(:title_tag) + ' - ' : '' %>Overwatch Team Comps
+    </title>
     <%= csrf_meta_tags %>
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <meta content="width=device-width,initial-scale=1" name="viewport">

--- a/app/views/pages/styleguide.html.erb
+++ b/app/views/pages/styleguide.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title_tag) do %>Style Guide<% end %>
 <div class="container">
   <h1>Style Guide</h1>
   <section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
     get "/composition/:slug" => "compositions#show", as: :composition
     post "/compositions" => "compositions#save", as: :compositions
 
-    resources :players, only: [:create]
+    resources :players, only: [:create, :update]
 
     resources :maps, only: [:index]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
     get "/composition/:slug" => "compositions#show", as: :composition
     post "/compositions" => "compositions#save", as: :compositions
 
-    resources :players, only: [:create, :update]
+    resources :players, only: [:create, :update, :destroy]
 
     resources :maps, only: [:index]
 

--- a/spec/controllers/players_controller_spec.rb
+++ b/spec/controllers/players_controller_spec.rb
@@ -3,7 +3,44 @@ require 'rails_helper'
 RSpec.describe PlayersController, type: :controller do
   before(:each) do
     @anon_user = create(:anonymous_user)
+    @user = create(:user)
     @map = create(:map)
+  end
+
+  context 'PUT update' do
+    it 'updates existing player owned by the user' do
+      player = create(:player, creator: @user)
+      composition = create(:composition, user: @user)
+
+      sign_in @user
+      expect do
+        put :update, params: {
+          format: :json, id: player.id, name: 'new name',
+          battletag: 'new battletag', composition_id: composition.id
+        }
+      end.not_to change { Player.count }
+
+      expect(response).to be_success
+      expect(player.reload.name).to eq('new name')
+      expect(player.battletag).to eq('new battletag')
+    end
+
+    it "will not update another user's player" do
+      player = create(:player, name: 'old name', battletag: 'old battletag')
+      composition = create(:composition, user: @user)
+
+      sign_in @user
+      expect do
+        put :update, params: {
+          format: :json, id: player.id, name: 'new name',
+          battletag: 'new battletag', composition_id: composition.id
+        }
+      end.not_to change { Player.count }
+
+      expect(response).to have_http_status(404)
+      expect(player.reload.name).to eq('old name')
+      expect(player.battletag).to eq('old battletag')
+    end
   end
 
   context 'POST create' do

--- a/spec/controllers/players_controller_spec.rb
+++ b/spec/controllers/players_controller_spec.rb
@@ -7,6 +7,36 @@ RSpec.describe PlayersController, type: :controller do
     @map = create(:map)
   end
 
+  context 'DELETE destroy' do
+    it 'deletes player owned by the user' do
+      player = create(:player, creator: @user)
+      composition = create(:composition, user: @user)
+
+      sign_in @user
+      expect do
+        delete :destroy, params: {
+          format: :json, id: player.id, composition_id: composition.id
+        }
+      end.to change { Player.count }.by(-1)
+
+      expect(response).to be_success
+    end
+
+    it 'will not delete player owned by another user' do
+      player = create(:player)
+      composition = create(:composition, user: @user)
+
+      sign_in @user
+      expect do
+        delete :destroy, params: {
+          format: :json, id: player.id, composition_id: composition.id
+        }
+      end.not_to change { Player.count }
+
+      expect(response).to have_http_status(404)
+    end
+  end
+
   context 'PUT update' do
     it 'updates existing player owned by the user' do
       player = create(:player, creator: @user)

--- a/spec/models/composition_player_spec.rb
+++ b/spec/models/composition_player_spec.rb
@@ -13,6 +13,25 @@ RSpec.describe CompositionPlayer, type: :model do
     expect(comp_player.errors[:player].any?).to be_truthy
   end
 
+  it 'decrements later comp player positions on destroy' do
+    comp = create(:composition)
+    comp_player1 = create(:composition_player, composition: comp,
+                          position: 0)
+    comp_player2 = create(:composition_player, composition: comp,
+                          position: 1)
+    comp_player3 = create(:composition_player, composition: comp,
+                          position: 2)
+    comp_player4 = create(:composition_player, composition: comp,
+                          position: 3)
+
+    expect { comp_player2.destroy }.
+      to change { CompositionPlayer.count }.by(-1)
+
+    expect(comp_player1.reload.position).to eq(0)
+    expect(comp_player3.reload.position).to eq(1)
+    expect(comp_player4.reload.position).to eq(2)
+  end
+
   it 'sets position' do
     comp_player = create(:composition_player, position: nil)
     expect(comp_player.position).to eq(0)

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -71,4 +71,26 @@ describe Player do
       expect(result).to eq(player)
     end
   end
+
+  it 'decrements positions of subsequent players in comp on destroy' do
+    user = create(:user)
+    comp = create(:composition, user: user)
+
+    player1 = create(:player, creator: user)
+    player2 = create(:player, creator: user)
+    player3 = create(:player, creator: user)
+
+    comp_player1 = create(:composition_player, composition: comp,
+                          position: 0, player: player1)
+    comp_player2 = create(:composition_player, composition: comp,
+                          position: 1, player: player2)
+    comp_player3 = create(:composition_player, composition: comp,
+                          position: 2, player: player3)
+
+    expect { player2.destroy }.
+      to change { CompositionPlayer.count }.by(-1)
+
+    expect(comp_player1.reload.position).to eq(0)
+    expect(comp_player3.reload.position).to eq(1)
+  end
 end


### PR DESCRIPTION
This fixes #67.

- Adds a new gear button next to players so you can edit or delete them.
- Lets you rename your players or set their battletag.
- Lets you delete players you created.
- Sets a title on each page so as you go back/forward in your browser history, it's easy to tell which page is which.
- Lets you back out of the 'create new player' form by hitting Esc when the new name input is focused.
- Ensures data integrity by deleting associated `composition_players` when a `players` record is deleted.

**Edit modal:**

<img width="1228" alt="team_composition_form_-_overwatch_team_comps" src="https://cloud.githubusercontent.com/assets/82317/24325355/389cb61a-1165-11e7-963b-c4f7d3319e46.png">

----

**Delete confirmation:**

<img width="469" alt="team_composition_form_-_overwatch_team_comps" src="https://cloud.githubusercontent.com/assets/82317/24325361/49aa6240-1165-11e7-86a2-1e57a852ccdd.png">

/cc @smbriones and @justbarreto for thoughts on the UI