### PR TITLE
Set up JavaScript test framework

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react"]
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,12 @@
         "sourceType": "module"
     },
     "globals": {
-        "React": true
+        "React": true,
+        "afterEach": true,
+        "beforeEach": true,
+        "describe": true,
+        "expect": true,
+        "test": true
     },
     "plugins": [
         "react",
@@ -33,6 +38,7 @@
         "react/require-default-props": 0,
         "react/jsx-no-bind": 0,
         "no-plusplus": 0,
-        "arrow-parens": 0
+        "arrow-parens": 0,
+        "no-param-reassign": [2, { "props": false }]
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,9 @@
         "react/jsx-no-bind": 0,
         "no-plusplus": 0,
         "arrow-parens": 0,
-        "no-param-reassign": [2, { "props": false }]
+        "no-param-reassign": [2, { "props": false }],
+        "import/no-extraneous-dependencies": [2, {
+            "devDependencies": true, "optionalDependencies": false, "peerDependencies": false
+        }]
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 
 node_modules
 npm-debug.log
+coverage

--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ npm test # to run the JavaScript style checker and JavaScript tests
 bundle exec rspec # to run Rails tests
 ```
 
+You can run just the style checker via `npm run style`. You can run just
+the JavaScript tests via `npm run unit-test`.
+
+Snapshots are used in JavaScript tests --
+see [`spec/javascript/components/__snapshots__/`](spec/javascript/components/__snapshots__/) --
+to test that a React component is rendered the same way consistently based
+on the props it's given. If you update a component, a test may fail
+because the snapshot is now different from what is rendered. Manually
+compare the two and if the change is expected, update the now out-of-date
+snapshot with `npm run unit-test -- -u`.
+
 ## How to Deploy to Heroku
 
 Create an [app on Heroku](https://dashboard.heroku.com/apps).

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ brew services stop postgresql
 After running through the development setup above, then:
 
 ```bash
-npm run style # to run the JavaScript style checker
+npm test # to run the JavaScript style checker and JavaScript tests
 bundle exec rspec # to run Rails tests
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ because the snapshot is now different from what is rendered. Manually
 compare the two and if the change is expected, update the now out-of-date
 snapshot with `npm run unit-test -- -u`.
 
+See also these links about the JavaScript tests:
+
+- [Shallow rendering with Enzyme](http://airbnb.io/enzyme/docs/api/shallow.html)
+- [Jest matchers](https://facebook.github.io/jest/docs/expect.html#content)
+- [ESLint rules](http://eslint.org/docs/rules/)
+
 ## How to Deploy to Heroku
 
 Create an [app on Heroku](https://dashboard.heroku.com/apps).

--- a/package.json
+++ b/package.json
@@ -35,10 +35,18 @@
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
+    "babel-jest": "^18.0.0",
+    "enzyme": "^2.7.1",
     "eslint": "^3.17.0",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-react": "^6.10.0"
+    "eslint-plugin-react": "^6.10.0",
+    "jest": "^18.1.0",
+    "jest-cli": "^18.1.0",
+    "jest-enzyme": "^2.1.2",
+    "react-addons-test-utils": "^15.4.2",
+    "react-shallow-render": "^1.0.1",
+    "react-test-renderer": "^15.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "style": "node_modules/.bin/eslint --ext .js --ext .jsx app/assets/javascripts/application.js app/assets/javascripts/components app/assets/javascripts/models spec/javascript spec/setup-jest.js",
     "unit-test": "node_modules/.bin/jest",
-    "test": "npm run style && npm test"
+    "test": "npm run style && npm run unit-test"
   },
   "homepage": "https://github.com/cheshire137/overwatch-team-comps",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/cheshire137/overwatch-team-comps/issues"
   },
   "scripts": {
-    "style": "node_modules/.bin/eslint --ext .js --ext .jsx app/assets/javascripts/application.js app/assets/javascripts/components app/assets/javascripts/models"
+    "style": "node_modules/.bin/eslint --ext .js --ext .jsx app/assets/javascripts/application.js app/assets/javascripts/components app/assets/javascripts/models spec/javascript spec/setup-jest.js"
   },
   "homepage": "https://github.com/cheshire137/overwatch-team-comps",
   "dependencies": {
@@ -42,11 +42,21 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.0",
+    "fetch-mock": "^5.9.4",
     "jest": "^18.1.0",
     "jest-cli": "^18.1.0",
     "jest-enzyme": "^2.1.2",
     "react-addons-test-utils": "^15.4.2",
     "react-shallow-render": "^1.0.1",
     "react-test-renderer": "^15.4.2"
+  },
+  "jest": {
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "app/assets/javascripts/**/*.{js,jsx}"
+    ],
+    "setupFiles": [
+      "<rootDir>/spec/setup-jest.js"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "url": "https://github.com/cheshire137/overwatch-team-comps/issues"
   },
   "scripts": {
-    "style": "node_modules/.bin/eslint --ext .js --ext .jsx app/assets/javascripts/application.js app/assets/javascripts/components app/assets/javascripts/models spec/javascript spec/setup-jest.js"
+    "style": "node_modules/.bin/eslint --ext .js --ext .jsx app/assets/javascripts/application.js app/assets/javascripts/components app/assets/javascripts/models spec/javascript spec/setup-jest.js",
+    "unit-test": "node_modules/.bin/jest",
+    "test": "npm run style && npm test"
   },
   "homepage": "https://github.com/cheshire137/overwatch-team-comps",
   "dependencies": {
@@ -53,7 +55,9 @@
   "jest": {
     "collectCoverage": true,
     "collectCoverageFrom": [
-      "app/assets/javascripts/**/*.{js,jsx}"
+      "app/assets/javascripts/**/*.{js,jsx}",
+      "!app/assets/javascripts/application.js",
+      "!app/assets/javascripts/cable.js"
     ],
     "setupFiles": [
       "<rootDir>/spec/setup-jest.js"

--- a/spec/javascript/components/__snapshots__/about.test.jsx.snap
+++ b/spec/javascript/components/__snapshots__/about.test.jsx.snap
@@ -1,0 +1,29 @@
+exports[`About matches snapshot 1`] = `
+<div
+  className="container about-page">
+  <h1>
+    About
+  </h1>
+  <p>
+    Thanks to Blizzard for Overwatch. 
+    <i
+      aria-hidden="true"
+      className="fa fa-heart" />
+     This app was built with 
+    <a
+      href="https://facebook.github.io/react/"
+      rel="noopener noreferrer"
+      target="_blank">
+      React
+    </a>
+     and 
+    <a
+      href="http://rubyonrails.org/"
+      rel="noopener noreferrer"
+      target="_blank">
+      Ruby on Rails
+    </a>
+    .
+  </p>
+</div>
+`;

--- a/spec/javascript/components/__snapshots__/anon-layout.test.jsx.snap
+++ b/spec/javascript/components/__snapshots__/anon-layout.test.jsx.snap
@@ -1,0 +1,46 @@
+exports[`AnonLayout matches snapshot 1`] = `
+<div
+  className="layout-container">
+  <div
+    className="container">
+    <nav
+      className="nav">
+      <div
+        className="nav-right">
+        <a
+          className="nav-item"
+          href="/">
+          Team composition
+        </a>
+        <a
+          className="nav-item"
+          href="/users/auth/bnet">
+          Sign in with Battle.net
+        </a>
+      </div>
+    </nav>
+  </div>
+  <div
+    className="layout-children-container">
+    <p>
+      Hey there
+    </p>
+  </div>
+  <footer
+    className="footer">
+    <div
+      className="container">
+      <a
+        href="/about">
+        About
+      </a>
+      <a
+        href="https://github.com/cheshire137/overwatch-team-comps"
+        rel="noopener noreferrer"
+        target="_blank">
+        View source
+      </a>
+    </div>
+  </footer>
+</div>
+`;

--- a/spec/javascript/components/__snapshots__/auth-layout.test.jsx.snap
+++ b/spec/javascript/components/__snapshots__/auth-layout.test.jsx.snap
@@ -1,0 +1,53 @@
+exports[`AuthLayout matches snapshot 1`] = `
+<div
+  className="layout-container">
+  <div
+    className="container">
+    <nav
+      className="nav">
+      <div
+        className="nav-right">
+        <a
+          className="nav-item is-active"
+          href="/user">
+          Team composition
+        </a>
+        <a
+          className="nav-item "
+          href="/user/hero-pool">
+          Your hero pool
+        </a>
+        <span
+          className="nav-item">
+          Signed in as 
+          <strong>
+            cheetos#1234
+          </strong>
+        </span>
+      </div>
+    </nav>
+  </div>
+  <div
+    className="layout-children-container">
+    <p>
+      Hey there
+    </p>
+  </div>
+  <footer
+    className="footer">
+    <div
+      className="container">
+      <a
+        href="/user/about">
+        About
+      </a>
+      <a
+        href="https://github.com/cheshire137/overwatch-team-comps"
+        rel="noopener noreferrer"
+        target="_blank">
+        View source
+      </a>
+    </div>
+  </footer>
+</div>
+`;

--- a/spec/javascript/components/__snapshots__/not-found.test.jsx.snap
+++ b/spec/javascript/components/__snapshots__/not-found.test.jsx.snap
@@ -1,0 +1,5 @@
+exports[`NotFound matches snapshot 1`] = `
+<h1>
+  404 Not Found
+</h1>
+`;

--- a/spec/javascript/components/about.test.jsx
+++ b/spec/javascript/components/about.test.jsx
@@ -1,0 +1,16 @@
+import renderer from 'react-test-renderer'
+
+import About from '../../../app/assets/javascripts/components/about.jsx'
+
+describe('About', () => {
+  let component = null
+
+  beforeEach(() => {
+    component = <About />
+  })
+
+  test('matches snapshot', () => {
+    const tree = renderer.create(component).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/spec/javascript/components/anon-layout.test.jsx
+++ b/spec/javascript/components/anon-layout.test.jsx
@@ -1,0 +1,19 @@
+import renderer from 'react-test-renderer'
+
+import AnonLayout from '../../../app/assets/javascripts/components/anon-layout.jsx'
+
+describe('AnonLayout', () => {
+  let component = null
+
+  beforeEach(() => {
+    const location = { pathname: '/about' }
+    component = (
+      <AnonLayout location={location}><p>Hey there</p></AnonLayout>
+    )
+  })
+
+  test('matches snapshot', () => {
+    const tree = renderer.create(component).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/spec/javascript/components/auth-layout.test.jsx
+++ b/spec/javascript/components/auth-layout.test.jsx
@@ -1,0 +1,26 @@
+import renderer from 'react-test-renderer'
+
+import mockLocalStorage from '../mocks/local-storage'
+
+import AuthLayout from '../../../app/assets/javascripts/components/auth-layout.jsx'
+
+describe('AuthLayout', () => {
+  let component = null
+
+  beforeEach(() => {
+    const store = {
+      'overwatch-team-comps': JSON.stringify({ battletag: 'cheetos#1234' })
+    }
+    mockLocalStorage(store)
+
+    const location = { pathname: '/user' }
+    component = (
+      <AuthLayout location={location}><p>Hey there</p></AuthLayout>
+    )
+  })
+
+  test('matches snapshot', () => {
+    const tree = renderer.create(component).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/spec/javascript/components/not-found.test.jsx
+++ b/spec/javascript/components/not-found.test.jsx
@@ -1,0 +1,16 @@
+import renderer from 'react-test-renderer'
+
+import NotFound from '../../../app/assets/javascripts/components/not-found.jsx'
+
+describe('NotFound', () => {
+  let component = null
+
+  beforeEach(() => {
+    component = <NotFound />
+  })
+
+  test('matches snapshot', () => {
+    const tree = renderer.create(component).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/spec/javascript/mocks/local-storage.js
+++ b/spec/javascript/mocks/local-storage.js
@@ -1,0 +1,10 @@
+function mockLocalStorage(store) {
+  window.localStorage = {
+    getItem: key => store[key],
+    setItem: (key, value) => {
+      store[key] = String(value)
+    }
+  }
+}
+
+export default mockLocalStorage

--- a/spec/javascript/models/local-storage.test.js
+++ b/spec/javascript/models/local-storage.test.js
@@ -1,0 +1,32 @@
+import LocalStorage from '../../../app/assets/javascripts/models/local-storage'
+
+import mockLocalStorage from '../mocks/local-storage'
+
+describe('LocalStorage', () => {
+  beforeEach(() => {
+    const store = {}
+    mockLocalStorage(store)
+  })
+
+  test('fetches saved local values as JSON', () => {
+    expect(LocalStorage.getJSON()).toEqual({})
+  })
+
+  test('can set and retrieve a value', () => {
+    LocalStorage.set('foo', 'bar')
+    expect(LocalStorage.get('foo')).toBe('bar')
+  })
+
+  test('can check if key has been set', () => {
+    expect(LocalStorage.has('foo')).toBe(false)
+    LocalStorage.set('foo', 'bar')
+    expect(LocalStorage.has('foo')).toBe(true)
+  })
+
+  test('can remove a key', () => {
+    LocalStorage.set('foo', 'bar')
+    expect(LocalStorage.has('foo')).toBe(true)
+    LocalStorage.delete('foo')
+    expect(LocalStorage.has('foo')).toBe(false)
+  })
+})

--- a/spec/setup-jest.js
+++ b/spec/setup-jest.js
@@ -1,7 +1,10 @@
 import fetchMock from 'fetch-mock'
+import React from 'react'
 
 // Ensure we're not talking to any external service by making all
 // unmocked requests return a 503 response code.
 //
 // http://www.wheresrhys.co.uk/fetch-mock/api
 fetchMock.catch(503)
+
+global.React = React

--- a/spec/setup-jest.js
+++ b/spec/setup-jest.js
@@ -1,0 +1,7 @@
+import fetchMock from 'fetch-mock'
+
+// Ensure we're not talking to any external service by making all
+// unmocked requests return a 503 response code.
+//
+// http://www.wheresrhys.co.uk/fetch-mock/api
+fetchMock.catch(503)


### PR DESCRIPTION
This fixes #20 by adding a few basic model and component tests. All it's testing right now for components is that they render. We can add more functionality tests later, e.g., when you click a button a thing happens, this is just a start.

This adds a new npm script so that `npm test` can be run to run JavaScript tests as well as the JavaScript style checker. We can make use of this in #17 on Travis.