### PR TITLE
Properly set battletag in local storage

### DIFF
--- a/app/assets/javascripts/components/app.jsx
+++ b/app/assets/javascripts/components/app.jsx
@@ -16,8 +16,10 @@ import OverwatchTeamCompsApi from '../models/overwatch-team-comps-api'
 function requireAuth(nextState, replace, callback) {
   const api = new OverwatchTeamCompsApi()
   api.getUser().then(json => {
-    LocalStorage.set('battletag', json.battletag)
-    if (!json.auth) {
+    if (json.auth) {
+      LocalStorage.set('battletag', json.battletag)
+    } else {
+      LocalStorage.delete('battletag')
       replace({
         pathname: '/',
         state: { nextPathname: nextState.location.pathname }
@@ -31,30 +33,33 @@ function redirectIfSignedIn(nextState, replace, callback) {
     const battletag = LocalStorage.get('battletag')
     if (battletag && battletag.length > 0) {
       replace({
+        pathname: `/user${nextState.location.pathname}`,
+        state: { nextPathname: nextState.location.pathname }
+      })
+      callback()
+      return
+    }
+  }
+
+  const api = new OverwatchTeamCompsApi()
+  api.getUser().then(json => {
+    if (json.auth) {
+      LocalStorage.set('battletag', json.battletag)
+      replace({
         pathname: '/user',
         state: { nextPathname: nextState.location.pathname }
       })
+    } else {
+      LocalStorage.delete('battletag')
     }
-    callback()
-  } else {
-    const api = new OverwatchTeamCompsApi()
-    api.getUser().then(json => {
-      LocalStorage.set('battletag', json.battletag)
-      if (json.auth) {
-        replace({
-          pathname: '/user',
-          state: { nextPathname: nextState.location.pathname }
-        })
-      }
-    }).then(callback)
-  }
+  }).then(callback)
 }
 
 const App = function() {
   return (
     <Router history={browserHistory}>
-      <Route path="/" component={AnonLayout}>
-        <IndexRoute component={CompositionForm} onEnter={redirectIfSignedIn} />
+      <Route path="/" component={AnonLayout} onEnter={redirectIfSignedIn}>
+        <IndexRoute component={CompositionForm} />
         <Route path="about" component={About} />
       </Route>
       <Route path="/comp" component={CompositionViewLayout}>

--- a/app/assets/javascripts/components/app.jsx
+++ b/app/assets/javascripts/components/app.jsx
@@ -29,11 +29,13 @@ function requireAuth(nextState, replace, callback) {
 }
 
 function redirectIfSignedIn(nextState, replace, callback) {
+  const newPath = `/user${nextState.location.pathname}`
+
   if (LocalStorage.has('battletag')) {
     const battletag = LocalStorage.get('battletag')
     if (battletag && battletag.length > 0) {
       replace({
-        pathname: `/user${nextState.location.pathname}`,
+        pathname: newPath,
         state: { nextPathname: nextState.location.pathname }
       })
       callback()
@@ -46,7 +48,7 @@ function redirectIfSignedIn(nextState, replace, callback) {
     if (json.auth) {
       LocalStorage.set('battletag', json.battletag)
       replace({
-        pathname: '/user',
+        pathname: newPath,
         state: { nextPathname: nextState.location.pathname }
       })
     } else {


### PR DESCRIPTION
Fixes #104 by deleting the battletag from local storage when the user is not signed in, instead of setting it to `null`.

This also redirects the user to /user/about from /about if they're signed in, so they see the authenticated-user nav bar up top.

/cc @RobThePM 