### PR TITLE
Disable form fields while request is pending

### DIFF
--- a/app/assets/javascripts/components/composition-form-header.jsx
+++ b/app/assets/javascripts/components/composition-form-header.jsx
@@ -45,18 +45,20 @@ class CompositionHeader extends React.Component {
 
   nameEditArea() {
     const { editingName, name } = this.state
+    const { disabled } = this.props
     let pencilIcon = null
     let saveButton = null
 
     if (editingName) {
       saveButton = (
         <button
+          disabled={disabled}
           type="button"
           className="button save-composition-name-button"
           onClick={e => this.saveNewName(e)}
         ><i className="fa fa-check" aria-hidden="true" /></button>
       )
-    } else {
+    } else if (!disabled) {
       pencilIcon = (
         <i
           className="fa fa-pencil-square-o"
@@ -74,6 +76,7 @@ class CompositionHeader extends React.Component {
           placeholder="Composition name"
           id="composition_name"
           value={name || ''}
+          disabled={disabled}
           onChange={e => this.onNameChange(e)}
           onFocus={() => this.setState({ editingName: true })}
           aria-label="Name of this team composition"
@@ -111,19 +114,22 @@ class CompositionHeader extends React.Component {
       return null
     }
 
-    const { mapID, mapSlug } = this.props
+    const { mapID, mapSlug, disabled } = this.props
     return (
       <header className={`composition-header gradient-${mapSlug}`}>
         <div className="container">
           <div className={`map-photo-container background-${mapSlug}`} />
           <div className="composition-meta">
             <div>
-              <span className="select map-select">
+              <span
+                className={`select map-select ${disabled ? 'is-disabled' : ''}`}
+              >
                 <select
                   aria-label="Choose a map"
                   id="composition_map_id"
                   value={mapID}
                   onChange={e => this.onMapChange(e)}
+                  disabled={disabled}
                 >
                   {maps.map(map =>
                     <option
@@ -149,7 +155,8 @@ CompositionHeader.propTypes = {
   mapID: React.PropTypes.number.isRequired,
   mapSlug: React.PropTypes.string.isRequired,
   onMapChange: React.PropTypes.func.isRequired,
-  onNameChange: React.PropTypes.func.isRequired
+  onNameChange: React.PropTypes.func.isRequired,
+  disabled: React.PropTypes.bool.isRequired
 }
 
 export default CompositionHeader

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -168,6 +168,11 @@ export default class CompositionForm extends React.Component {
     }
   }
 
+  selectedPlayerCount() {
+    return this.state.players.
+      filter(p => typeof p.id === 'number').length
+  }
+
   render() {
     const { name, slug, mapID, mapSegments, players, heroes,
             selections, notes, mapSlug, editingPlayerID, id } = this.state
@@ -176,8 +181,6 @@ export default class CompositionForm extends React.Component {
       return <p className="container">Loading...</p>
     }
 
-    const selectedPlayerCount = players.
-      filter(p => typeof p.id === 'number').length
     const editingPlayer = typeof editingPlayerID === 'number'
       ? players.filter(p => p.id === editingPlayerID)[0]
       : null
@@ -197,7 +200,9 @@ export default class CompositionForm extends React.Component {
             <thead>
               <tr>
                 <th className="players-header small-fat-header">
-                  <span className="player-count">{selectedPlayerCount} / 6</span>
+                  <span className="player-count">
+                    {this.selectedPlayerCount()} / 6
+                  </span>
                   Team
                 </th>
                 {mapSegments.map((segment, i) => (

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -258,6 +258,7 @@ export default class CompositionForm extends React.Component {
                     key={key}
                     inputID={inputID}
                     playerID={player.id}
+                    disabled={isRequestOut}
                     players={selectablePlayers}
                     heroes={playerHeroes}
                     selections={playerSelections}

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -173,6 +173,16 @@ export default class CompositionForm extends React.Component {
       filter(p => typeof p.id === 'number').length
   }
 
+  getPlayerToEdit() {
+    const { players, editingPlayerID } = this.state
+
+    if (typeof editingPlayerID === 'number') {
+      return players.filter(player => player.id === editingPlayerID)[0]
+    }
+
+    return null
+  }
+
   render() {
     const { name, slug, mapID, mapSegments, players, heroes,
             selections, notes, mapSlug, editingPlayerID, id } = this.state
@@ -181,9 +191,7 @@ export default class CompositionForm extends React.Component {
       return <p className="container">Loading...</p>
     }
 
-    const editingPlayer = typeof editingPlayerID === 'number'
-      ? players.filter(p => p.id === editingPlayerID)[0]
-      : null
+    const editingPlayer = this.getPlayerToEdit()
 
     return (
       <form className="composition-form">

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -284,6 +284,7 @@ export default class CompositionForm extends React.Component {
             <textarea
               id="composition_notes"
               className="textarea"
+              disabled={isRequestOut}
               placeholder="Notes for this team composition"
               value={notes || ''}
               onChange={e => this.onCompositionNotesChange(e)}

--- a/app/assets/javascripts/components/edit-player-selection-row.jsx
+++ b/app/assets/javascripts/components/edit-player-selection-row.jsx
@@ -4,7 +4,7 @@ import PlayerSelect from './player-select.jsx'
 const EditPlayerSelectionRow = function(props) {
   const { inputID, playerID, nameLabel, onHeroSelection,
           mapSegments, onPlayerSelection, players, heroes,
-          selections, editPlayer } = props
+          selections, editPlayer, disabled } = props
   return (
     <tr>
       <td className="player-cell">
@@ -13,6 +13,7 @@ const EditPlayerSelectionRow = function(props) {
           label={nameLabel}
           playerID={playerID}
           players={players}
+          disabled={disabled}
           onChange={(newPlayerID, newName) =>
             onPlayerSelection(newPlayerID, newName)
           }
@@ -47,7 +48,8 @@ EditPlayerSelectionRow.propTypes = {
   mapSegments: React.PropTypes.array.isRequired,
   heroes: React.PropTypes.array.isRequired,
   selections: React.PropTypes.object.isRequired,
-  editPlayer: React.PropTypes.func.isRequired
+  editPlayer: React.PropTypes.func.isRequired,
+  disabled: React.PropTypes.bool.isRequired
 }
 
 export default EditPlayerSelectionRow

--- a/app/assets/javascripts/components/edit-player-selection-row.jsx
+++ b/app/assets/javascripts/components/edit-player-selection-row.jsx
@@ -27,7 +27,7 @@ const EditPlayerSelectionRow = function(props) {
         >
           <HeroSelect
             heroes={heroes}
-            disabled={typeof playerID !== 'number'}
+            disabled={disabled || typeof playerID !== 'number'}
             selectedHeroID={selections[segment.id]}
             onChange={heroID => onHeroSelection(heroID, segment.id)}
             selectID={`${inputID}_segment_${segment.id}`}

--- a/app/assets/javascripts/components/hero-select.jsx
+++ b/app/assets/javascripts/components/hero-select.jsx
@@ -29,7 +29,9 @@ class HeroSelect extends React.Component {
         <label
           htmlFor={selectID}
         >{this.heroPortrait()}</label>
-        <span className="select">
+        <span
+          className={`select ${disabled ? 'is-disabled' : ''}`}
+        >
           <select
             onChange={e => this.onChange(e)}
             value={selectedHeroID || ''}

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -1,7 +1,6 @@
 class PlayerSelect extends React.Component {
   constructor(props) {
     super(props)
-
     this.state = { name: '', showNewNameField: false }
   }
 
@@ -43,7 +42,7 @@ class PlayerSelect extends React.Component {
   }
 
   selectOrTextField() {
-    const { playerID, inputID, players } = this.props
+    const { playerID, inputID, players, disabled } = this.props
 
     if (this.state.showNewNameField) {
       return (
@@ -52,6 +51,7 @@ class PlayerSelect extends React.Component {
             type="text"
             id={inputID}
             placeholder="Player name"
+            disabled={disabled}
             value={this.state.name}
             onChange={e => this.onNewNameSet(e)}
             onKeyDown={e => this.onNewNameKeyDown(e)}
@@ -62,6 +62,7 @@ class PlayerSelect extends React.Component {
             <button
               type="button"
               className="button"
+              disabled={disabled}
               onClick={e => this.saveNewName(e)}
             ><i className="fa fa-check" aria-hidden="true" /></button>
           </div>
@@ -73,9 +74,12 @@ class PlayerSelect extends React.Component {
 
     return (
       <div className="existing-player-container">
-        <span className="select player-select">
+        <span
+          className={`select player-select ${disabled ? 'is-disabled' : ''}`}
+        >
           <select
             onChange={e => this.onChange(e)}
+            disabled={disabled}
             value={isPlayerSelected ? playerID : ''}
           >
             <option value="">Player</option>
@@ -91,6 +95,7 @@ class PlayerSelect extends React.Component {
         {isPlayerSelected ? (
           <button
             type="button"
+            disabled={disabled}
             className="button-link edit-player-button"
             onClick={e => this.editPlayer(e)}
           ><i className="fa fa-cog" aria-hidden="true" /></button>
@@ -119,7 +124,8 @@ PlayerSelect.propTypes = {
   players: React.PropTypes.array.isRequired,
   onChange: React.PropTypes.func.isRequired,
   label: React.PropTypes.string.isRequired,
-  editPlayer: React.PropTypes.func.isRequired
+  editPlayer: React.PropTypes.func.isRequired,
+  disabled: React.PropTypes.bool.isRequired
 }
 
 export default PlayerSelect

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -223,6 +223,14 @@
     height: 2.3rem;
     padding-left: 0;
     padding-right: 0;
+
+    &[disabled] {
+      color: $soft-text;
+    }
+  }
+
+  &.is-disabled:after {
+    border-color: $soft-text;
   }
 
   &:after {

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -189,6 +189,14 @@
   border-color: $defend;
 }
 
+.input[disabled],
+.textarea[disabled] {
+  background-color: whitesmoke;
+  border-color: whitesmoke;
+  box-shadow: none;
+  color: #7a7a7a;
+}
+
 .field {
   .label {
     font-weight: 700;


### PR DESCRIPTION
Fixes #69 by disabling inputs, select menus, and textareas when requests are pending. This adds a visual cue for the user that the app is doing something, and also will help prevent one request's actions from clobbering another.