### PR TITLE
Only show default option when none has been selected yet

### DIFF
--- a/app/assets/javascripts/components/hero-select.jsx
+++ b/app/assets/javascripts/components/hero-select.jsx
@@ -34,11 +34,13 @@ class HeroSelect extends React.Component {
         >
           <select
             onChange={e => this.onChange(e)}
-            value={selectedHeroID || ''}
+            value={isFilled ? selectedHeroID : ''}
             disabled={disabled}
             id={selectID}
           >
-            <option>Hero</option>
+            {isFilled ? '' : (
+              <option value="">Hero</option>
+            )}
             {heroes.map(hero => (
               <option
                 key={hero.id}

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -82,7 +82,9 @@ class PlayerSelect extends React.Component {
             disabled={disabled}
             value={isPlayerSelected ? playerID : ''}
           >
-            <option value="">Player</option>
+            {isPlayerSelected ? '' : (
+              <option value="">Player</option>
+            )}
             {players.map(player => (
               <option
                 key={player.id}


### PR DESCRIPTION
Fixes #112 by no longer showing 'Hero' in hero select menus once a hero has been chosen. Similarly, no longer shows 'Player' in player select menus once a player has been chosen.