### PR TITLE
Allow creating multiple compositions for a map

### DIFF
--- a/app/assets/javascripts/components/composition-form-header.jsx
+++ b/app/assets/javascripts/components/composition-form-header.jsx
@@ -59,7 +59,6 @@ class CompositionHeader extends React.Component {
   }
 
   onMapsFetched(maps) {
-    console.log('loaded maps')
     this.setState({ maps })
   }
 
@@ -84,7 +83,6 @@ class CompositionHeader extends React.Component {
 
   compositionSelect() {
     const { disabled, compositionSlug } = this.props
-    console.log('selected comp', compositionSlug)
     const compositions = this.getCompositionsForSelectedMap()
 
     return (

--- a/app/assets/javascripts/components/composition-form-header.jsx
+++ b/app/assets/javascripts/components/composition-form-header.jsx
@@ -165,6 +165,18 @@ class CompositionHeader extends React.Component {
     )
   }
 
+  compositionSelect() {
+    const { name } = this.state
+
+    return (
+      <span className="select composition-select">
+        <select>
+          <option>{name}</option>
+        </select>
+      </span>
+    )
+  }
+
   render() {
     const { maps } = this.state
     if (typeof maps === 'undefined') {
@@ -178,7 +190,7 @@ class CompositionHeader extends React.Component {
           {this.mapPhotoContainer()}
           <div className="composition-meta">
             {this.mapSelect()}
-            {this.nameEditArea()}
+            {this.compositionSelect()}
             {this.shareLink()}
           </div>
         </div>

--- a/app/assets/javascripts/components/composition-form-header.jsx
+++ b/app/assets/javascripts/components/composition-form-header.jsx
@@ -189,22 +189,28 @@ class CompositionHeader extends React.Component {
     const className = `select map-select ${disabled ? 'is-disabled' : ''}`
 
     return (
-      <span className={className}>
-        <select
-          aria-label="Choose a map"
-          id="composition_map_id"
-          value={mapID}
-          onChange={e => this.onMapChange(e)}
-          disabled={disabled}
-        >
-          {maps.map(map =>
-            <option
-              key={map.id}
-              value={map.id}
-            >{map.name}</option>
-          )}
-        </select>
-      </span>
+      <div className="map-select-container">
+        <label
+          htmlFor="composition_map_id"
+        ><i className="fa fa-map-marker" aria-hidden="true" /></label>
+        <span className={className}>
+          <select
+            aria-label="Choose a map"
+            title="Choose a map"
+            id="composition_map_id"
+            value={mapID}
+            onChange={e => this.onMapChange(e)}
+            disabled={disabled}
+          >
+            {maps.map(map =>
+              <option
+                key={map.id}
+                value={map.id}
+              >{map.name}</option>
+            )}
+          </select>
+        </span>
+      </div>
     )
   }
 

--- a/app/assets/javascripts/components/composition-form-header.jsx
+++ b/app/assets/javascripts/components/composition-form-header.jsx
@@ -44,14 +44,17 @@ class CompositionHeader extends React.Component {
 
   saveNewName(event) {
     event.preventDefault()
+
     const button = event.target.closest('button')
     if (button) { // maybe user hit Enter to save, not clicked button
       button.blur() // defocus the button
     }
+
     const { name } = this.state
     if (name.trim().length < 1) {
       return
     }
+
     this.props.onNameChange(name)
   }
 
@@ -121,46 +124,60 @@ class CompositionHeader extends React.Component {
     )
   }
 
+  mapSelect() {
+    const { maps } = this.state
+    const { mapID, disabled } = this.props
+    const className = `select map-select ${disabled ? 'is-disabled' : ''}`
+
+    return (
+      <span className={className}>
+        <select
+          aria-label="Choose a map"
+          id="composition_map_id"
+          value={mapID}
+          onChange={e => this.onMapChange(e)}
+          disabled={disabled}
+        >
+          {maps.map(map =>
+            <option
+              key={map.id}
+              value={map.id}
+            >{map.name}</option>
+          )}
+        </select>
+      </span>
+    )
+  }
+
+  mapPhotoContainer() {
+    const { mapSlug, mapImage } = this.props
+
+    return (
+      <div className={`map-photo-container background-${mapSlug}`}>
+        {mapImage ? (
+          <img
+            src={mapImage}
+            alt={mapSlug}
+            className="map-photo"
+          />
+        ) : ''}
+      </div>
+    )
+  }
+
   render() {
     const { maps } = this.state
     if (typeof maps === 'undefined') {
       return null
     }
 
-    const { mapID, mapSlug, mapImage, disabled } = this.props
+    const { mapSlug } = this.props
     return (
       <header className={`composition-header gradient-${mapSlug}`}>
         <div className="container">
-          <div className={`map-photo-container background-${mapSlug}`}>
-            {mapImage ? (
-              <img
-                src={mapImage}
-                alt={mapSlug}
-                className="map-photo"
-              />
-            ) : ''}
-          </div>
+          {this.mapPhotoContainer()}
           <div className="composition-meta">
-            <div>
-              <span
-                className={`select map-select ${disabled ? 'is-disabled' : ''}`}
-              >
-                <select
-                  aria-label="Choose a map"
-                  id="composition_map_id"
-                  value={mapID}
-                  onChange={e => this.onMapChange(e)}
-                  disabled={disabled}
-                >
-                  {maps.map(map =>
-                    <option
-                      key={map.id}
-                      value={map.id}
-                    >{map.name}</option>
-                  )}
-                </select>
-              </span>
-            </div>
+            {this.mapSelect()}
             {this.nameEditArea()}
             {this.shareLink()}
           </div>

--- a/app/assets/javascripts/components/composition-form-header.jsx
+++ b/app/assets/javascripts/components/composition-form-header.jsx
@@ -101,7 +101,7 @@ class CompositionHeader extends React.Component {
       <span className="select composition-select">
         <select
           disabled={disabled}
-          value={compositionSlug}
+          value={compositionSlug || ''}
           onChange={e => this.onCompositionSelected(e)}
         >
           {compositions.map(composition => (

--- a/app/assets/javascripts/components/composition-form-header.jsx
+++ b/app/assets/javascripts/components/composition-form-header.jsx
@@ -15,11 +15,7 @@ class CompositionHeader extends React.Component {
   }
 
   componentDidMount() {
-    const api = new OverwatchTeamCompsApi()
-
-    api.getMaps().
-      then(maps => this.onMapsFetched(maps)).
-      catch(err => CompositionHeader.onMapsError(err))
+    this.loadMaps()
   }
 
   componentWillReceiveProps(nextProps) {
@@ -27,6 +23,14 @@ class CompositionHeader extends React.Component {
       compositionName: nextProps.compositionName,
       editingName: false,
       creatingNewComposition: false
+    }, () => {
+      const currentMap = (this.state.maps || []).filter(map => map.id === nextProps.mapID)[0]
+      if (currentMap) {
+        const knownSlugs = currentMap.compositions.map(comp => comp.slug)
+        if (knownSlugs.indexOf(nextProps.compositionSlug) < 0) {
+          this.loadMaps()
+        }
+      }
     })
   }
 
@@ -79,6 +83,14 @@ class CompositionHeader extends React.Component {
     }
 
     return []
+  }
+
+  loadMaps() {
+    const api = new OverwatchTeamCompsApi()
+
+    api.getMaps().
+      then(maps => this.onMapsFetched(maps)).
+      catch(err => CompositionHeader.onMapsError(err))
   }
 
   compositionSelect() {

--- a/app/assets/javascripts/components/composition-form-header.jsx
+++ b/app/assets/javascripts/components/composition-form-header.jsx
@@ -21,16 +21,16 @@ class CompositionHeader extends React.Component {
     this.setState({ name: nextProps.name, editingName: false })
   }
 
-  onNameChange(event) {
+  onCompositionNameChange(event) {
     this.setState({ name: event.target.value })
   }
 
-  onNameKeyDown(event) {
+  onCompositionNameKeyDown(event) {
     if (event.keyCode === 27) { // Esc
       event.target.blur() // defocus input field
       this.setState({ editingName: false })
     } else if (event.keyCode === 13) { // Enter
-      this.saveNewName(event)
+      this.saveCompositionName(event)
     }
   }
 
@@ -42,7 +42,7 @@ class CompositionHeader extends React.Component {
     this.props.onMapChange(event.target.value)
   }
 
-  saveNewName(event) {
+  saveCompositionName(event) {
     event.preventDefault()
 
     const button = event.target.closest('button')
@@ -58,47 +58,43 @@ class CompositionHeader extends React.Component {
     this.props.onNameChange(name)
   }
 
-  nameEditArea() {
+  compositionNameEditor() {
     const { editingName, name } = this.state
     const { disabled } = this.props
-    let pencilIcon = null
-    let saveButton = null
 
     if (editingName) {
-      saveButton = (
-        <button
-          disabled={disabled}
-          type="button"
-          className="button save-composition-name-button"
-          onClick={e => this.saveNewName(e)}
-        ><i className="fa fa-check" aria-hidden="true" /></button>
-      )
-    } else if (!disabled) {
-      pencilIcon = (
-        <i
-          className="fa fa-pencil-square-o"
-          aria-hidden="true"
-        />
+      return (
+        <div className={`composition-name-container ${editingName ? 'editing' : ''}`}>
+          <input
+            type="text"
+            className="input composition-name-input"
+            placeholder="Composition name"
+            id="composition_name"
+            value={name || ''}
+            disabled={disabled}
+            onKeyDown={e => this.onCompositionNameKeyDown(e)}
+            onChange={e => this.onCompositionNameChange(e)}
+            onFocus={() => this.setState({ editingName: true })}
+            aria-label="Name of this team composition"
+          />
+          <button
+            disabled={disabled}
+            type="button"
+            className="button save-composition-name-button"
+            onClick={e => this.saveCompositionName(e)}
+          ><i className="fa fa-check" aria-hidden="true" /></button>
+        </div>
       )
     }
 
     return (
-      <div className={`composition-name-container ${editingName ? 'editing' : ''}`}>
-        {pencilIcon}
-        <input
-          type="text"
-          className="input composition-name-input"
-          placeholder="Composition name"
-          id="composition_name"
-          value={name || ''}
+      <span className="select composition-select">
+        <select
           disabled={disabled}
-          onKeyDown={e => this.onNameKeyDown(e)}
-          onChange={e => this.onNameChange(e)}
-          onFocus={() => this.setState({ editingName: true })}
-          aria-label="Name of this team composition"
-        />
-        {saveButton}
-      </div>
+        >
+          <option>{name}</option>
+        </select>
+      </span>
     )
   }
 
@@ -165,15 +161,25 @@ class CompositionHeader extends React.Component {
     )
   }
 
-  compositionSelect() {
-    const { name } = this.state
+  toggleCompositionNameEditor(event) {
+    event.currentTarget.blur() // defocus the button
+    this.setState({ editingName: !this.state.editingName })
+  }
 
+  compositionSelectAndEdit() {
+    const { editingName } = this.state
     return (
-      <span className="select composition-select">
-        <select>
-          <option>{name}</option>
-        </select>
-      </span>
+      <div className="composition-select-container">
+        {this.compositionNameEditor()}
+        {editingName ? '' : (
+          <button
+            type="button"
+            title="Edit team composition name"
+            className="button-link edit-composition-name-button"
+            onClick={e => this.toggleCompositionNameEditor(e)}
+          ><i className="fa fa-pencil" aria-hidden="true" /></button>
+        )}
+      </div>
     )
   }
 
@@ -190,7 +196,7 @@ class CompositionHeader extends React.Component {
           {this.mapPhotoContainer()}
           <div className="composition-meta">
             {this.mapSelect()}
-            {this.compositionSelect()}
+            {this.compositionSelectAndEdit()}
             {this.shareLink()}
           </div>
         </div>

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -61,7 +61,6 @@ export default class CompositionForm extends React.Component {
       body.composition_id = id
     }
 
-    console.log('saving name', name, create ? 'as new composition' : 'to update existing composition')
     this.setState({ isRequestOut: true }, () => {
       api.saveComposition(body).
         then(newComp => this.onCompositionLoaded(newComp)).

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -49,7 +49,7 @@ export default class CompositionForm extends React.Component {
     this.setState({ isRequestOut: false })
   }
 
-  onCompositionNameChange(name) {
+  onCompositionNameChange(name, create) {
     const { id, mapID } = this.state
     const api = new OverwatchTeamCompsApi()
 
@@ -57,10 +57,11 @@ export default class CompositionForm extends React.Component {
       name,
       map_id: mapID
     }
-    if (id) {
+    if (id && !create) {
       body.composition_id = id
     }
 
+    console.log('saving name', name, create ? 'as new composition' : 'to update existing composition')
     this.setState({ isRequestOut: true }, () => {
       api.saveComposition(body).
         then(newComp => this.onCompositionLoaded(newComp)).
@@ -152,6 +153,16 @@ export default class CompositionForm extends React.Component {
     })
   }
 
+  loadCompositionBySlug(slug) {
+    const api = new OverwatchTeamCompsApi()
+
+    this.setState({ isRequestOut: true }, () => {
+      api.getComposition(slug).
+        then(comp => this.onCompositionLoaded(comp)).
+        catch(err => this.onCompositionFetchError(err))
+    })
+  }
+
   createPlayer(playerName, position) {
     const { id, mapID } = this.state
     const body = {
@@ -216,13 +227,18 @@ export default class CompositionForm extends React.Component {
     return (
       <form className="composition-form">
         <CompositionFormHeader
-          name={name}
-          slug={slug}
+          compositionName={name}
+          compositionSlug={slug}
           mapID={mapID}
           mapSlug={mapSlug}
           mapImage={mapImage}
           disabled={isRequestOut}
-          onNameChange={newName => this.onCompositionNameChange(newName)}
+          onCompositionNameChange={(newName, create) =>
+            this.onCompositionNameChange(newName, create)
+          }
+          onCompositionLoad={slugToLoad =>
+            this.loadCompositionBySlug(slugToLoad)
+          }
           onMapChange={newMapID => this.onMapChange(newMapID)}
         />
         <div className="container">

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -30,14 +30,17 @@ class PlayerSelect extends React.Component {
 
   saveNewName(event) {
     event.preventDefault()
+
     const name = this.state.name
     if (name.trim().length < 1) {
       return
     }
+
     const existingNames = this.props.players.map(p => p.name)
     if (existingNames.indexOf(name) > -1) {
       return
     }
+
     this.props.onChange(null, name)
   }
 

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -16,6 +16,8 @@ class PlayerSelect extends React.Component {
   onNewNameKeyDown(event) {
     if (event.keyCode === 27) { // Esc
       this.setState({ showNewNameField: false })
+    } else if (event.keyCode === 13) { // Enter
+      this.saveNewName(event)
     }
   }
 

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -231,9 +231,26 @@
       color: $soft-text;
     }
   }
+}
 
-  &:after {
-    right: 0.6em;
+.composition-select-container {
+  display: table;
+}
+
+.select.composition-select,
+.edit-composition-name-button,
+.composition-name-container {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.edit-composition-name-button {
+  height: 2.4em;
+  color: $soft-header;
+
+  &:hover,
+  &:focus {
+    color: $white;
   }
 }
 
@@ -265,6 +282,7 @@
     border-width: 3px;
     width: 0.6em;
     height: 0.6em;
+    right: 0.6em;
   }
 }
 
@@ -293,7 +311,6 @@
     border: none;
     padding-left: 0;
     padding-right: 20px;
-    font-size: 1.3rem;
     line-height: 1;
     height: auto;
     @include border-radius(0);
@@ -305,7 +322,6 @@
 
     .input.composition-name-input {
       border-bottom: 1px solid $defend;
-      color: $white;
     }
   }
 }

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -220,6 +220,8 @@
 }
 
 .select.map-select {
+  display: block;
+
   select {
     color: $white;
     font-size: 1.7rem;

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -224,12 +224,17 @@
   display: block;
 
   select {
+    color: $white;
     padding-left: 0;
     padding-right: 0;
 
     &[disabled] {
       color: $soft-text;
     }
+  }
+
+  &:after {
+    border-color: $white;
   }
 }
 
@@ -257,17 +262,11 @@
 .select.composition-select {
   select {
     width: 100%;
-    color: $soft-header;
-  }
-
-  &:after {
-    border-color: $soft-header;
   }
 }
 
 .select.map-select {
   select {
-    color: $white;
     font-size: 1.7rem;
     line-height: 1;
     height: 2.3rem;
@@ -278,7 +277,6 @@
   }
 
   &:after {
-    border-color: $white;
     border-width: 3px;
     width: 0.6em;
     height: 0.6em;
@@ -307,7 +305,7 @@
 
   .input.composition-name-input {
     background-color: transparent;
-    color: $soft-header;
+    color: $white;
     border: none;
     padding-left: 0;
     padding-right: 20px;
@@ -365,7 +363,7 @@
   margin-top: 10px;
 
   .composition-link {
-    color: $soft-text;
+    color: $soft-header;
     text-decoration: none;
     font-size: 0.9rem;
 

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -219,6 +219,24 @@
   }
 }
 
+.map-select-container {
+  display: table;
+
+  .fa,
+  .select.map-select {
+    display: table-cell;
+    vertical-align: middle;
+  }
+
+  .fa {
+    font-size: 1.3rem;
+    padding-right: 10px;
+    color: $soft-text;
+    line-height: 1;
+    height: 2.5rem;
+  }
+}
+
 .select.composition-select,
 .select.map-select {
   display: block;

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -219,20 +219,41 @@
   }
 }
 
+.select.composition-select,
 .select.map-select {
   display: block;
 
   select {
-    color: $white;
-    font-size: 1.7rem;
-    line-height: 1;
-    height: 2.3rem;
     padding-left: 0;
     padding-right: 0;
 
     &[disabled] {
       color: $soft-text;
     }
+  }
+
+  &:after {
+    right: 0.6em;
+  }
+}
+
+.select.composition-select {
+  select {
+    width: 100%;
+    color: $soft-header;
+  }
+
+  &:after {
+    border-color: $soft-header;
+  }
+}
+
+.select.map-select {
+  select {
+    color: $white;
+    font-size: 1.7rem;
+    line-height: 1;
+    height: 2.3rem;
   }
 
   &.is-disabled:after {
@@ -244,7 +265,6 @@
     border-width: 3px;
     width: 0.6em;
     height: 0.6em;
-    right: 0.6em;
   }
 }
 

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -260,6 +260,8 @@
 }
 
 .select.composition-select {
+  min-width: 11em;
+
   select {
     width: 100%;
   }

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -226,7 +226,6 @@
   select {
     color: $white;
     padding-left: 0;
-    padding-right: 0;
 
     &[disabled] {
       color: $soft-text;
@@ -264,6 +263,7 @@
 
   select {
     width: 100%;
+    padding-right: 2em;
   }
 }
 
@@ -272,6 +272,7 @@
     font-size: 1.7rem;
     line-height: 1;
     height: 2.3rem;
+    padding-right: 0;
   }
 
   &.is-disabled:after {

--- a/app/controllers/compositions_controller.rb
+++ b/app/controllers/compositions_controller.rb
@@ -1,6 +1,7 @@
 class CompositionsController < ApplicationController
   def show
     @composition = Composition.friendly.find(params[:slug])
+    @composition.touch_if_mine(user: current_user, session_id: session.id)
     @builder = CompositionFormBuilder.new(@composition)
     @available_players = []
   end

--- a/app/controllers/compositions_controller.rb
+++ b/app/controllers/compositions_controller.rb
@@ -2,8 +2,14 @@ class CompositionsController < ApplicationController
   def show
     @composition = Composition.friendly.find(params[:slug])
     @composition.touch_if_mine(user: current_user, session_id: session.id)
+
     @builder = CompositionFormBuilder.new(@composition)
-    @available_players = []
+
+    @available_players = if @composition.mine?(user: current_user, session_id: session.id)
+      @composition.available_players(user: current_user, session_id: session.id)
+    else
+      []
+    end
   end
 
   def last_composition

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,5 +1,15 @@
 class MapsController < ApplicationController
   def index
     @maps = Map.includes(:segments).order(:name)
+
+    compositions = Composition.where(map_id: @maps.pluck(:id)).
+      created_by(user: current_user, session_id: session.id)
+
+    @compositions_by_map = {}
+    @maps.each { |map| @compositions_by_map[map.id] ||= [] }
+
+    compositions.each do |composition|
+      @compositions_by_map[composition.map_id] << composition
+    end
   end
 end

--- a/app/models/composition.rb
+++ b/app/models/composition.rb
@@ -70,6 +70,22 @@ class Composition < ApplicationRecord
     ]
   end
 
+  # Returns true if this Composition is owned by the given user.
+  def mine?(user:, session_id:)
+    if user
+      self.user == user
+    else
+      self.user.anonymous? && self.session_id == session_id
+    end
+  end
+
+  # Updates this Composition's updated_at if it belongs to the given user.
+  def touch_if_mine(user:, session_id:)
+    return unless mine?(user: user, session_id: session_id)
+
+    touch
+  end
+
   private
 
   def user_has_not_used_name_before

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -2,6 +2,7 @@ class Map < ApplicationRecord
   extend FriendlyId
 
   has_many :segments, dependent: :destroy, class_name: "MapSegment"
+  has_many :compositions, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
 

--- a/app/views/maps/index.json.jbuilder
+++ b/app/views/maps/index.json.jbuilder
@@ -9,5 +9,6 @@ json.maps @maps do |map|
   json.compositions @compositions_by_map[map.id] do |composition|
     json.id composition.id
     json.name composition.name
+    json.slug composition.slug
   end
 end

--- a/app/views/maps/index.json.jbuilder
+++ b/app/views/maps/index.json.jbuilder
@@ -6,4 +6,8 @@ json.maps @maps do |map|
     json.id map_segment.id
     json.name map_segment.name
   end
+  json.compositions @compositions_by_map[map.id] do |composition|
+    json.id composition.id
+    json.name composition.name
+  end
 end

--- a/spec/controllers/compositions_controller_spec.rb
+++ b/spec/controllers/compositions_controller_spec.rb
@@ -1,9 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe CompositionsController do
+  before(:all) do
+    @anon_user = User.anonymous || create(:anonymous_user)
+  end
+
   before(:each) do
     @user = create(:user)
-    @anon_user = create(:anonymous_user)
     @map = create(:map)
     @map_segment1 = create(:map_segment, map: @map)
     @map_segment2 = create(:map_segment, map: @map)

--- a/spec/controllers/players_controller_spec.rb
+++ b/spec/controllers/players_controller_spec.rb
@@ -1,8 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe PlayersController, type: :controller do
+  before(:all) do
+    @anon_user = User.anonymous || create(:anonymous_user)
+  end
+
   before(:each) do
-    @anon_user = create(:anonymous_user)
     @user = create(:user)
     @map = create(:map)
   end

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Users::OmniauthCallbacksController do
+  before(:all) do
+    @anon_user = User.anonymous || create(:anonymous_user)
+  end
+
   before(:each) do
     OmniAuth.config.test_mode = true
 
@@ -13,8 +17,6 @@ RSpec.describe Users::OmniauthCallbacksController do
     @request.session.id = '8675309'
     @request.env['devise.mapping'] = Devise.mappings[:user]
     @request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:bnet]
-
-    @anon_user = create(:anonymous_user)
   end
 
   describe 'POST bnet' do

--- a/spec/models/composition_spec.rb
+++ b/spec/models/composition_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 describe Composition do
+  before(:all) do
+    @anon_user = User.anonymous || create(:anonymous_user)
+  end
+
   it "requires a map" do
     composition = Composition.new
     expect(composition.valid?).to be_falsey
@@ -20,8 +24,7 @@ describe Composition do
   end
 
   it 'requires a session ID if the user is anonymous' do
-    anon_user = create(:anonymous_user)
-    composition = Composition.new(user: anon_user)
+    composition = Composition.new(user: @anon_user)
     expect(composition.valid?).to be_falsey
     expect(composition.errors[:session_id].any?).to be_truthy
   end
@@ -35,18 +38,16 @@ describe Composition do
   end
 
   it 'sets composition name for anonymous user scoped by session' do
-    anon_user = create(:anonymous_user)
-
     session1 = '123abc'
     session2 = '987zyx'
 
-    session1_comp = create(:composition, user: anon_user, session_id: session1)
+    session1_comp = create(:composition, user: @anon_user, session_id: session1)
     expect(session1_comp.name).to eq('Composition 1')
 
-    session2_comp = create(:composition, user: anon_user, session_id: session2)
+    session2_comp = create(:composition, user: @anon_user, session_id: session2)
     expect(session2_comp.name).to eq('Composition 1')
 
-    session1_comp2 = build(:composition, user: anon_user, session_id: session1)
+    session1_comp2 = build(:composition, user: @anon_user, session_id: session1)
     session1_comp2.valid?
     expect(session1_comp2.name).to eq('Composition 2')
   end
@@ -59,8 +60,7 @@ describe Composition do
   end
 
   it 'requires a unique name per user for anonymous user' do
-    anon_user = create(:anonymous_user)
-    existing = create(:composition, user: anon_user, session_id: '123abc')
+    existing = create(:composition, user: @anon_user, session_id: '123abc')
     composition = Composition.new(name: existing.name, user: existing.user,
                                   session_id: existing.session_id)
     expect(composition.valid?).to be_falsey

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 describe Player do
+  before(:all) do
+    @anon_user = User.anonymous || create(:anonymous_user)
+  end
+
   it "requires a name" do
     player = Player.new
     expect(player.valid?).to be_falsey
@@ -16,9 +20,8 @@ describe Player do
   end
 
   it 'requires a unique name per anonymous creator' do
-    anon_user = create(:anonymous_user)
-    player1 = create(:player, creator: anon_user, creator_session_id: '123')
-    player2 = build(:player, creator: anon_user, name: player1.name,
+    player1 = create(:player, creator: @anon_user, creator_session_id: '123')
+    player2 = build(:player, creator: @anon_user, name: player1.name,
                     creator_session_id: player1.creator_session_id)
     expect(player2.valid?).to be_falsey
     expect(player2.errors[:name].any?).to be_truthy
@@ -31,8 +34,7 @@ describe Player do
   end
 
   it 'requires a creator session ID if the creator is anonymous' do
-    anon_user = create(:anonymous_user)
-    player = Player.new(creator: anon_user)
+    player = Player.new(creator: @anon_user)
     expect(player.valid?).to be_falsey
     expect(player.errors[:creator_session_id].any?).to be_truthy
   end
@@ -58,8 +60,7 @@ describe Player do
     end
 
     it 'returns owned player for anonymous user' do
-      anon_user = create(:anonymous_user)
-      player = create(:player, creator: anon_user, creator_session_id: '123')
+      player = create(:player, creator: @anon_user, creator_session_id: '123')
       result = Player.find_if_allowed(player.id, user: nil, session_id: '123')
       expect(result).to eq(player)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 describe User do
-  context "Anonymous user" do
-    before do
-      create :anonymous_user
-    end
+  before(:all) do
+    User.anonymous || create(:anonymous_user)
+  end
 
+  context "Anonymous user" do
     it "found via email" do
       expect(User.find_by_email(User::ANONYMOUS_EMAIL)).to_not be_nil
     end


### PR DESCRIPTION
This fixes #115 by letting the user create multiple compositions per map. You can switch between compositions and create a new composition via a select menu that takes the place of the composition name field in the header area. You can still rename your compositions via the pencil icon to the right of the menu.

<img width="438" alt="team_composition_form_-_overwatch_team_comps" src="https://cloud.githubusercontent.com/assets/82317/24582363/3205d194-16f4-11e7-899e-dc1b18174ce3.png">

This also fixes the bug from #118 by making it so that when you hit Enter in the player name input, it no longer reloads the page and instead saves the player name you entered.