### PR TITLE
Show map image on composition view page

### DIFF
--- a/app/assets/javascripts/components/composition-view.jsx
+++ b/app/assets/javascripts/components/composition-view.jsx
@@ -26,6 +26,7 @@ class CompositionView extends React.Component {
       name: null,
       mapName: null,
       mapSlug: null,
+      mapImage: null,
       players: [],
       selections: {},
       heroes: {}
@@ -51,7 +52,8 @@ class CompositionView extends React.Component {
       players: composition.players,
       selections: composition.selections,
       heroes: composition.heroes,
-      mapSlug: composition.map.slug
+      mapSlug: composition.map.slug,
+      mapImage: composition.map.image
     })
   }
 
@@ -80,7 +82,7 @@ class CompositionView extends React.Component {
 
   render() {
     const { mapName, mapSegments, name, players, selections,
-            heroes, notes, mapSlug } = this.state
+            heroes, notes, mapSlug, mapImage } = this.state
 
     if (typeof mapName === 'undefined') {
       return <p className="container">Loading...</p>
@@ -90,7 +92,15 @@ class CompositionView extends React.Component {
       <div>
         <header className={`composition-header gradient-${mapSlug}`}>
           <div className="container">
-            <div className="map-photo-container" />
+            <div className={`map-photo-container background-${mapSlug}`}>
+              {mapImage ? (
+                <img
+                  src={mapImage}
+                  alt={mapSlug}
+                  className="map-photo"
+                />
+              ) : ''}
+            </div>
             <div className="composition-meta">
               <div className="composition-map-name">
                 {mapName}

--- a/app/assets/javascripts/components/composition-view.jsx
+++ b/app/assets/javascripts/components/composition-view.jsx
@@ -76,7 +76,9 @@ class CompositionView extends React.Component {
     const month = date.getMonth()
     const year = date.getFullYear()
     return (
-      <span>Last updated: {days[day]}, {months[month]} {dayOfMonth}, {year}</span>
+      <p
+        className="composition-updated-date"
+      >Updated: {days[day]}, {months[month]} {dayOfMonth}, {year}</p>
     )
   }
 
@@ -108,10 +110,7 @@ class CompositionView extends React.Component {
               <div className="composition-name">
                 {name}
               </div>
-              <div className="composition-creator-and-date">
-                {this.compositionCreator()}
-                {this.compositionDate()}
-              </div>
+              {this.compositionCreator()}
             </div>
           </div>
         </header>
@@ -157,6 +156,7 @@ class CompositionView extends React.Component {
               {notes}
             </div>
           </div>
+          {this.compositionDate()}
         </div>
       </div>
     )

--- a/app/assets/stylesheets/composition-view.scss
+++ b/app/assets/stylesheets/composition-view.scss
@@ -1,9 +1,5 @@
-.composition-creator-and-date {
-  margin-top: 5px;
-
-  .composition-creator:after {
-    content: "\a0\b7\a0";
-  }
+.composition-creator:after {
+  content: "\a0\b7\a0";
 }
 
 .composition-map-name {
@@ -17,7 +13,6 @@
   color: $soft-header;
   font-size: 1.3rem;
   line-height: 1.3;
-  margin-bottom: 5px;
 }
 
 .players-view-table.players-table {
@@ -46,4 +41,10 @@
     margin-left: 10px;
     white-space: nowrap;
   }
+}
+
+.composition-updated-date {
+  text-transform: uppercase;
+  font-size: 12px;
+  margin: 40px 0;
 }


### PR DESCRIPTION
Fixes #113 by showing the map image on the view page for a composition, not just the composition form:

<img width="819" alt="hana_comp_-_hanamura_-_overwatch_team_comps" src="https://cloud.githubusercontent.com/assets/82317/24831542/108dc00e-1c61-11e7-85e3-6980bce23b81.png">
