### PR TITLE
Highlight duplicate hero selections

### DIFF
--- a/app/assets/javascripts/components/anon-layout.jsx
+++ b/app/assets/javascripts/components/anon-layout.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 import Footer from './footer.jsx'
 
 const AnonLayout = function(props) {
@@ -29,8 +31,8 @@ const AnonLayout = function(props) {
 }
 
 AnonLayout.propTypes = {
-  children: React.PropTypes.object.isRequired,
-  location: React.PropTypes.object.isRequired
+  children: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired
 }
 
 export default AnonLayout

--- a/app/assets/javascripts/components/auth-layout.jsx
+++ b/app/assets/javascripts/components/auth-layout.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 import Footer from './footer.jsx'
 
 import LocalStorage from '../models/local-storage'
@@ -140,8 +142,8 @@ class AuthLayout extends React.Component {
 }
 
 AuthLayout.propTypes = {
-  children: React.PropTypes.object.isRequired,
-  location: React.PropTypes.object.isRequired
+  children: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired
 }
 
 export default AuthLayout

--- a/app/assets/javascripts/components/composition-form-header.jsx
+++ b/app/assets/javascripts/components/composition-form-header.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 import OverwatchTeamCompsApi from '../models/overwatch-team-comps-api'
 
 class CompositionHeader extends React.Component {
@@ -275,15 +277,15 @@ class CompositionHeader extends React.Component {
 }
 
 CompositionHeader.propTypes = {
-  compositionName: React.PropTypes.string,
-  compositionSlug: React.PropTypes.string,
-  mapID: React.PropTypes.number.isRequired,
-  mapSlug: React.PropTypes.string.isRequired,
-  mapImage: React.PropTypes.string,
-  onMapChange: React.PropTypes.func.isRequired,
-  onCompositionNameChange: React.PropTypes.func.isRequired,
-  onCompositionLoad: React.PropTypes.func.isRequired,
-  disabled: React.PropTypes.bool.isRequired
+  compositionName: PropTypes.string,
+  compositionSlug: PropTypes.string,
+  mapID: PropTypes.number.isRequired,
+  mapSlug: PropTypes.string.isRequired,
+  mapImage: PropTypes.string,
+  onMapChange: PropTypes.func.isRequired,
+  onCompositionNameChange: PropTypes.func.isRequired,
+  onCompositionLoad: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 }
 
 export default CompositionHeader

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -20,6 +20,7 @@ export default class CompositionForm extends React.Component {
       availablePlayers: [],
       heroes: {},
       selections: {},
+      duplicatePicks: {},
       notes: '',
       editingPlayerID: null,
       isRequestOut: false
@@ -118,6 +119,7 @@ export default class CompositionForm extends React.Component {
       availablePlayers: composition.availablePlayers,
       heroes: composition.heroes,
       selections: composition.selections,
+      duplicatePicks: composition.duplicatePicks,
       notes: composition.notes
     })
   }
@@ -215,7 +217,7 @@ export default class CompositionForm extends React.Component {
   render() {
     const { name, slug, mapID, mapSegments, players, heroes,
             selections, notes, mapSlug, editingPlayerID, id,
-            isRequestOut, mapImage } = this.state
+            isRequestOut, mapImage, duplicatePicks } = this.state
 
     if (typeof mapID !== 'number') {
       return <p className="container">Loading...</p>
@@ -269,6 +271,7 @@ export default class CompositionForm extends React.Component {
                 const key = `${player.name}${index}`
                 const playerHeroes = typeof player.id === 'number' ? heroes[player.id] : []
                 const playerSelections = typeof player.id === 'number' ? selections[player.id] : {}
+                const playerDupes = typeof player.id === 'number' ? duplicatePicks[player.id] : {}
                 const selectablePlayers = this.getPlayerOptionsForRow(player)
 
                 return (
@@ -280,6 +283,7 @@ export default class CompositionForm extends React.Component {
                     players={selectablePlayers}
                     heroes={playerHeroes}
                     selections={playerSelections}
+                    duplicatePicks={playerDupes || {}}
                     mapSegments={mapSegments}
                     nameLabel={String(index + 1)}
                     onHeroSelection={(heroID, mapSegmentID) =>

--- a/app/assets/javascripts/components/composition-view-layout.jsx
+++ b/app/assets/javascripts/components/composition-view-layout.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 const CompositionViewLayout = function(props) {
   return (
     <div>
@@ -19,7 +21,7 @@ const CompositionViewLayout = function(props) {
 }
 
 CompositionViewLayout.propTypes = {
-  children: React.PropTypes.object.isRequired
+  children: PropTypes.object.isRequired
 }
 
 export default CompositionViewLayout

--- a/app/assets/javascripts/components/composition-view.jsx
+++ b/app/assets/javascripts/components/composition-view.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 import OverwatchTeamCompsApi from '../models/overwatch-team-comps-api'
 
 import MapSegmentHeader from './map-segment-header.jsx'
@@ -164,7 +166,7 @@ class CompositionView extends React.Component {
 }
 
 CompositionView.propTypes = {
-  params: React.PropTypes.object.isRequired
+  params: PropTypes.object.isRequired
 }
 
 export default CompositionView

--- a/app/assets/javascripts/components/edit-player-selection-row.jsx
+++ b/app/assets/javascripts/components/edit-player-selection-row.jsx
@@ -4,7 +4,7 @@ import PlayerSelect from './player-select.jsx'
 const EditPlayerSelectionRow = function(props) {
   const { inputID, playerID, nameLabel, onHeroSelection,
           mapSegments, onPlayerSelection, players, heroes,
-          selections, editPlayer, disabled } = props
+          selections, editPlayer, disabled, duplicatePicks } = props
   return (
     <tr>
       <td className="player-cell">
@@ -31,6 +31,7 @@ const EditPlayerSelectionRow = function(props) {
             selectedHeroID={selections[segment.id]}
             onChange={heroID => onHeroSelection(heroID, segment.id)}
             selectID={`${inputID}_segment_${segment.id}`}
+            isDuplicate={duplicatePicks[segment.id]}
           />
         </td>
       ))}
@@ -48,6 +49,7 @@ EditPlayerSelectionRow.propTypes = {
   mapSegments: React.PropTypes.array.isRequired,
   heroes: React.PropTypes.array.isRequired,
   selections: React.PropTypes.object.isRequired,
+  duplicatePicks: React.PropTypes.object.isRequired,
   editPlayer: React.PropTypes.func.isRequired,
   disabled: React.PropTypes.bool.isRequired
 }

--- a/app/assets/javascripts/components/edit-player-selection-row.jsx
+++ b/app/assets/javascripts/components/edit-player-selection-row.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 import HeroSelect from './hero-select.jsx'
 import PlayerSelect from './player-select.jsx'
 
@@ -40,18 +42,18 @@ const EditPlayerSelectionRow = function(props) {
 }
 
 EditPlayerSelectionRow.propTypes = {
-  inputID: React.PropTypes.string.isRequired,
-  playerID: React.PropTypes.number,
-  players: React.PropTypes.array.isRequired,
-  onPlayerSelection: React.PropTypes.func.isRequired,
-  nameLabel: React.PropTypes.string.isRequired,
-  onHeroSelection: React.PropTypes.func.isRequired,
-  mapSegments: React.PropTypes.array.isRequired,
-  heroes: React.PropTypes.array.isRequired,
-  selections: React.PropTypes.object.isRequired,
-  duplicatePicks: React.PropTypes.object.isRequired,
-  editPlayer: React.PropTypes.func.isRequired,
-  disabled: React.PropTypes.bool.isRequired
+  inputID: PropTypes.string.isRequired,
+  playerID: PropTypes.number,
+  players: PropTypes.array.isRequired,
+  onPlayerSelection: PropTypes.func.isRequired,
+  nameLabel: PropTypes.string.isRequired,
+  onHeroSelection: PropTypes.func.isRequired,
+  mapSegments: PropTypes.array.isRequired,
+  heroes: PropTypes.array.isRequired,
+  selections: PropTypes.object.isRequired,
+  duplicatePicks: PropTypes.object.isRequired,
+  editPlayer: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 }
 
 export default EditPlayerSelectionRow

--- a/app/assets/javascripts/components/footer.jsx
+++ b/app/assets/javascripts/components/footer.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 const Footer = function(props) {
   const { basePath } = props
   return (
@@ -15,7 +17,7 @@ const Footer = function(props) {
 }
 
 Footer.propTypes = {
-  basePath: React.PropTypes.string.isRequired
+  basePath: PropTypes.string.isRequired
 }
 
 export default Footer

--- a/app/assets/javascripts/components/hero-pool-choice.jsx
+++ b/app/assets/javascripts/components/hero-pool-choice.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 class HeroPoolChoice extends React.Component {
   onChange(event) {
     this.props.onChange(event.target.value)
@@ -65,13 +67,13 @@ class HeroPoolChoice extends React.Component {
 }
 
 HeroPoolChoice.propTypes = {
-  slug: React.PropTypes.string.isRequired,
-  image: React.PropTypes.string.isRequired,
-  id: React.PropTypes.number.isRequired,
-  confidence: React.PropTypes.number.isRequired,
-  name: React.PropTypes.string.isRequired,
-  onChange: React.PropTypes.func.isRequired,
-  ranks: React.PropTypes.object.isRequired
+  slug: PropTypes.string.isRequired,
+  image: PropTypes.string.isRequired,
+  id: PropTypes.number.isRequired,
+  confidence: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  ranks: PropTypes.object.isRequired
 }
 
 export default HeroPoolChoice

--- a/app/assets/javascripts/components/hero-select.jsx
+++ b/app/assets/javascripts/components/hero-select.jsx
@@ -21,17 +21,38 @@ class HeroSelect extends React.Component {
     )
   }
 
+  selectSpanClass() {
+    const classes = ['select']
+    if (this.props.disabled) {
+      classes.push('is-disabled')
+    }
+    return classes.join(' ')
+  }
+
+  isFilled() {
+    return typeof this.props.selectedHeroID === 'number'
+  }
+
+  containerClass() {
+    const classes = ['hero-select-container']
+    if (!this.isFilled()) {
+      classes.push('not-filled')
+    }
+    if (this.props.isDuplicate) {
+      classes.push('is-duplicate')
+    }
+    return classes.join(' ')
+  }
+
   render() {
     const { heroes, selectedHeroID, disabled, selectID } = this.props
-    const isFilled = typeof selectedHeroID === 'number'
+    const isFilled = this.isFilled()
     return (
-      <div className={`hero-select-container ${isFilled ? '' : 'not-filled'}`}>
+      <div className={this.containerClass()}>
         <label
           htmlFor={selectID}
         >{this.heroPortrait()}</label>
-        <span
-          className={`select ${disabled ? 'is-disabled' : ''}`}
-        >
+        <span className={this.selectSpanClass()}>
           <select
             onChange={e => this.onChange(e)}
             value={isFilled ? selectedHeroID : ''}
@@ -59,7 +80,8 @@ HeroSelect.propTypes = {
   onChange: React.PropTypes.func.isRequired,
   selectedHeroID: React.PropTypes.number,
   disabled: React.PropTypes.bool.isRequired,
-  selectID: React.PropTypes.string.isRequired
+  selectID: React.PropTypes.string.isRequired,
+  isDuplicate: React.PropTypes.bool
 }
 
 export default HeroSelect

--- a/app/assets/javascripts/components/hero-select.jsx
+++ b/app/assets/javascripts/components/hero-select.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 class HeroSelect extends React.Component {
   onChange(event) {
     const heroID = event.target.value
@@ -76,12 +78,12 @@ class HeroSelect extends React.Component {
 }
 
 HeroSelect.propTypes = {
-  heroes: React.PropTypes.array.isRequired,
-  onChange: React.PropTypes.func.isRequired,
-  selectedHeroID: React.PropTypes.number,
-  disabled: React.PropTypes.bool.isRequired,
-  selectID: React.PropTypes.string.isRequired,
-  isDuplicate: React.PropTypes.bool
+  heroes: PropTypes.array.isRequired,
+  onChange: PropTypes.func.isRequired,
+  selectedHeroID: PropTypes.number,
+  disabled: PropTypes.bool.isRequired,
+  selectID: PropTypes.string.isRequired,
+  isDuplicate: PropTypes.bool
 }
 
 export default HeroSelect

--- a/app/assets/javascripts/components/map-segment-header.jsx
+++ b/app/assets/javascripts/components/map-segment-header.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 class MapSegmentHeader extends React.Component {
   className() {
     const { index, isAttack } = this.props
@@ -46,12 +48,12 @@ class MapSegmentHeader extends React.Component {
 }
 
 MapSegmentHeader.propTypes = {
-  name: React.PropTypes.string.isRequired,
-  filled: React.PropTypes.bool.isRequired,
-  isAttack: React.PropTypes.bool.isRequired,
-  isFirstOfKind: React.PropTypes.bool.isRequired,
-  isLastOfKind: React.PropTypes.bool.isRequired,
-  index: React.PropTypes.number.isRequired
+  name: PropTypes.string.isRequired,
+  filled: PropTypes.bool.isRequired,
+  isAttack: PropTypes.bool.isRequired,
+  isFirstOfKind: PropTypes.bool.isRequired,
+  isLastOfKind: PropTypes.bool.isRequired,
+  index: PropTypes.number.isRequired
 }
 
 export default MapSegmentHeader

--- a/app/assets/javascripts/components/player-edit-modal.jsx
+++ b/app/assets/javascripts/components/player-edit-modal.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 import OverwatchTeamCompsApi from '../models/overwatch-team-comps-api'
 
 class PlayerEditModal extends React.Component {
@@ -217,12 +219,12 @@ class PlayerEditModal extends React.Component {
 }
 
 PlayerEditModal.propTypes = {
-  playerID: React.PropTypes.number,
-  compositionID: React.PropTypes.number,
-  playerName: React.PropTypes.string,
-  battletag: React.PropTypes.string,
-  close: React.PropTypes.func.isRequired,
-  isOpen: React.PropTypes.bool.isRequired
+  playerID: PropTypes.number,
+  compositionID: PropTypes.number,
+  playerName: PropTypes.string,
+  battletag: PropTypes.string,
+  close: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool.isRequired
 }
 
 export default PlayerEditModal

--- a/app/assets/javascripts/components/player-row-view.jsx
+++ b/app/assets/javascripts/components/player-row-view.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 class PlayerRowView extends React.Component {
   mapSegment(segment, index) {
     const { heroes, selections } = this.props
@@ -55,10 +57,10 @@ class PlayerRowView extends React.Component {
 }
 
 PlayerRowView.propTypes = {
-  heroes: React.PropTypes.array.isRequired,
-  name: React.PropTypes.string.isRequired,
-  selections: React.PropTypes.object.isRequired,
-  mapSegments: React.PropTypes.array.isRequired
+  heroes: PropTypes.array.isRequired,
+  name: PropTypes.string.isRequired,
+  selections: PropTypes.object.isRequired,
+  mapSegments: PropTypes.array.isRequired
 }
 
 export default PlayerRowView

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -33,8 +33,8 @@ class PlayerSelect extends React.Component {
   saveNewName(event) {
     event.preventDefault()
 
-    const name = this.state.name
-    if (name.trim().length < 1) {
+    const name = this.state.name.trim()
+    if (name.length < 1) {
       return
     }
 

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -66,7 +66,7 @@ class PlayerSelect extends React.Component {
           <div className="button-wrapper">
             <button
               type="button"
-              className="button"
+              className="button save-new-name-button"
               disabled={disabled}
               onClick={e => this.saveNewName(e)}
             ><i className="fa fa-check" aria-hidden="true" /></button>

--- a/app/assets/javascripts/components/player-select.jsx
+++ b/app/assets/javascripts/components/player-select.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 class PlayerSelect extends React.Component {
   constructor(props) {
     super(props)
@@ -126,13 +128,13 @@ class PlayerSelect extends React.Component {
 }
 
 PlayerSelect.propTypes = {
-  inputID: React.PropTypes.string.isRequired,
-  playerID: React.PropTypes.number,
-  players: React.PropTypes.array.isRequired,
-  onChange: React.PropTypes.func.isRequired,
-  label: React.PropTypes.string.isRequired,
-  editPlayer: React.PropTypes.func.isRequired,
-  disabled: React.PropTypes.bool.isRequired
+  inputID: PropTypes.string.isRequired,
+  playerID: PropTypes.number,
+  players: PropTypes.array.isRequired,
+  onChange: PropTypes.func.isRequired,
+  label: PropTypes.string.isRequired,
+  editPlayer: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired
 }
 
 export default PlayerSelect

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -118,6 +118,11 @@
       background-color: #f5f5f6;
     }
 
+    &.is-duplicate {
+      border-color: #f0dbdc;
+      background-color: #fbf4f5;
+    }
+
     label,
     .select {
       display: table-cell;

--- a/app/models/composition_row.rb
+++ b/app/models/composition_row.rb
@@ -5,6 +5,7 @@ class CompositionRow
     @number = number
     @player = player
     @builder = builder
+    @heroes_by_segment = {}
   end
 
   def heroes
@@ -16,12 +17,19 @@ class CompositionRow
   end
 
   def selected_hero(map_segment)
-    return unless player
+    if @heroes_by_segment.key?(map_segment.id)
+      return @heroes_by_segment[map_segment.id]
+    end
+
+    unless player
+      @heroes_by_segment[map_segment.id] = nil
+      return
+    end
 
     selection = @builder.player_selections.detect do |ps|
       ps.map_segment_id == map_segment.id &&
         ps.position == number && ps.player_id == player.id
     end
-    selection ? selection.hero_id : nil
+    @heroes_by_segment[map_segment.id] = selection ? selection.hero_id : nil
   end
 end

--- a/app/models/composition_row.rb
+++ b/app/models/composition_row.rb
@@ -1,35 +1,54 @@
 class CompositionRow
   attr_reader :player, :number
 
-  def initialize(number:, player:, builder:)
+  def initialize(number:, player:, all_heroes:, player_selections:,
+                 heroes_by_segment:)
     @number = number
     @player = player
-    @builder = builder
-    @heroes_by_segment = {}
+    @all_heroes = all_heroes
+    @selected_heroes = {}
+    @heroes_by_segment = heroes_by_segment
+    @player_selections = player_selections
   end
 
+  # Returns true if the selected hero for the given map segment is a
+  # duplicate pick for another player in the same map segment.
+  def duplicate?(map_segment)
+    maybe_hero_id = selected_hero(map_segment)
+    return false if maybe_hero_id.nil?
+
+    count = @heroes_by_segment[map_segment.id].
+      select { |hero_id| hero_id == maybe_hero_id }.size
+
+    count > 1
+  end
+
+  # Returns a list of heroes ordered with those the player is most confident
+  # on first.
   def heroes
     if player
-      player.heroes_by_confidence(@builder.heroes)
+      player.heroes_by_confidence(@all_heroes)
     else
-      @builder.heroes
+      @all_heroes
     end
   end
 
   def selected_hero(map_segment)
-    if @heroes_by_segment.key?(map_segment.id)
-      return @heroes_by_segment[map_segment.id]
+    if @selected_heroes.key?(map_segment.id)
+      return @selected_heroes[map_segment.id]
     end
 
     unless player
-      @heroes_by_segment[map_segment.id] = nil
+      @selected_heroes[map_segment.id] = nil
       return
     end
 
-    selection = @builder.player_selections.detect do |ps|
-      ps.map_segment_id == map_segment.id &&
-        ps.position == number && ps.player_id == player.id
+    selection = @player_selections.detect do |player_selection|
+      player_selection.position == number &&
+        player_selection.map_segment_id == map_segment.id &&
+        player_selection.player_id == player.id
     end
-    @heroes_by_segment[map_segment.id] = selection ? selection.hero_id : nil
+
+    @selected_heroes[map_segment.id] = selection ? selection.hero_id : nil
   end
 end

--- a/app/models/player_selection.rb
+++ b/app/models/player_selection.rb
@@ -11,6 +11,8 @@ class PlayerSelection < ApplicationRecord
   validates :composition_player_id, uniqueness: { scope: :map_segment_id }
   validate :map_segment_matches_composition_map
 
+  delegate :position, :player_id, :composition_id, to: :composition_player
+
   private
 
   def map_segment_matches_composition_map

--- a/app/models/player_selection.rb
+++ b/app/models/player_selection.rb
@@ -11,8 +11,6 @@ class PlayerSelection < ApplicationRecord
   validates :composition_player_id, uniqueness: { scope: :map_segment_id }
   validate :map_segment_matches_composition_map
 
-  delegate :position, :player_id, :composition_id, to: :composition_player
-
   private
 
   def map_segment_matches_composition_map

--- a/app/views/compositions/show.json.jbuilder
+++ b/app/views/compositions/show.json.jbuilder
@@ -56,13 +56,13 @@ json.composition do
   end
 
   if @builder.any_duplicates?
-    # Hash of player ID => map segment ID => hero ID
+    # Hash of player ID => map segment ID => Boolean
     json.duplicatePicks do
       @builder.rows.each do |row|
-        json.set! row.player.id do
-          @builder.map_segments.each do |map_segment|
-            if row.duplicate?(map_segment)
-              json.set! map_segment.id, row.selected_hero(map_segment)
+        if row.player
+          json.set! row.player.id do
+            @builder.map_segments.each do |map_segment|
+              json.set! map_segment.id, row.duplicate?(map_segment)
             end
           end
         end

--- a/app/views/compositions/show.json.jbuilder
+++ b/app/views/compositions/show.json.jbuilder
@@ -55,6 +55,23 @@ json.composition do
     end
   end
 
+  if @builder.any_duplicates?
+    # Hash of player ID => map segment ID => hero ID
+    json.duplicatePicks do
+      @builder.rows.each do |row|
+        json.set! row.player.id do
+          @builder.map_segments.each do |map_segment|
+            if row.duplicate?(map_segment)
+              json.set! map_segment.id, row.selected_hero(map_segment)
+            end
+          end
+        end
+      end
+    end
+  else
+    json.duplicatePicks Hash.new
+  end
+
   # Hash of player ID => map segment ID => hero ID
   json.selections do
     @builder.rows.each do |row|

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "browserify-incremental": "^3.1.1",
     "immutability-helper": "^2.1.2",
     "promise-polyfill": "^6.0.2",
+    "prop-types": "^15.5.6",
     "react": "^15.4.2",
     "react-debounce-input": "^2.4.2",
     "react-dom": "^15.4.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "collectCoverageFrom": [
       "app/assets/javascripts/**/*.{js,jsx}",
       "!app/assets/javascripts/application.js",
-      "!app/assets/javascripts/cable.js"
+      "!app/assets/javascripts/cable.js",
+      "!app/assets/javascripts/components.js"
     ],
     "setupFiles": [
       "<rootDir>/spec/setup-jest.js"

--- a/spec/javascript/components/__snapshots__/hero-select.test.jsx.snap
+++ b/spec/javascript/components/__snapshots__/hero-select.test.jsx.snap
@@ -1,0 +1,30 @@
+exports[`HeroSelect matches snapshot 1`] = `
+<div
+  className="hero-select-container">
+  <label
+    htmlFor="hero-select-dom-id">
+    <img
+      alt="Hanzo"
+      className="hero-portrait"
+      src="/photo.jpg" />
+  </label>
+  <span
+    className="select">
+    <select
+      disabled={false}
+      id="hero-select-dom-id"
+      onChange={[Function]}
+      value={1}>
+      
+      <option
+        value={1}>
+        Hanzo
+      </option>
+      <option
+        value={2}>
+        Ana
+      </option>
+    </select>
+  </span>
+</div>
+`;

--- a/spec/javascript/components/__snapshots__/player-select.test.jsx.snap
+++ b/spec/javascript/components/__snapshots__/player-select.test.jsx.snap
@@ -1,0 +1,43 @@
+exports[`PlayerSelect matches snapshot 1`] = `
+<div
+  className="player-select-container">
+  <label
+    className="label"
+    htmlFor="input-dom-id">
+    Player 1 selection
+  </label>
+  <div
+    className="existing-player-container">
+    <span
+      className="select player-select ">
+      <select
+        disabled={false}
+        onChange={[Function]}
+        value={1}>
+        
+        <option
+          value={1}>
+          Sally
+        </option>
+        <option
+          value={2}>
+          Jimmy
+        </option>
+        <option
+          value="new">
+          Add new player
+        </option>
+      </select>
+    </span>
+    <button
+      className="button-link edit-player-button"
+      disabled={false}
+      onClick={[Function]}
+      type="button">
+      <i
+        aria-hidden="true"
+        className="fa fa-cog" />
+    </button>
+  </div>
+</div>
+`;

--- a/spec/javascript/components/__snapshots__/settings.test.jsx.snap
+++ b/spec/javascript/components/__snapshots__/settings.test.jsx.snap
@@ -1,0 +1,107 @@
+exports[`Settings matches snapshot 1`] = `
+<div
+  className="container">
+  <form
+    className="settings-form"
+    onSubmit={[Function]}>
+    <div
+      className="field">
+      <label
+        className="label"
+        htmlFor="email">
+        Email address:
+      </label>
+      <input
+        className="input"
+        disabled={false}
+        id="email"
+        onChange={[Function]}
+        placeholder="Your email address"
+        type="text"
+        value={undefined} />
+    </div>
+    <div
+      className="field">
+      <label
+        className="label"
+        htmlFor="platform">
+        Which platform do you primarily play on?
+      </label>
+      <div>
+        <span
+          className="select ">
+          <select
+            disabled={false}
+            id="platform"
+            name="platform"
+            onChange={[Function]}
+            value={undefined}>
+            <option
+              value="" />
+            <option
+              value="pc">
+              PC
+            </option>
+            <option
+              value="psn">
+              PlayStation
+            </option>
+            <option
+              value="xbl">
+              Xbox
+            </option>
+          </select>
+        </span>
+      </div>
+    </div>
+    <div
+      className="field">
+      <label
+        className="label"
+        htmlFor="region">
+        Which region do you primarily play in?
+      </label>
+      <div>
+        <span
+          className="select ">
+          <select
+            disabled={false}
+            id="region"
+            name="region"
+            onChange={[Function]}
+            value={undefined}>
+            <option
+              value="" />
+            <option
+              value="us">
+              United States
+            </option>
+            <option
+              value="eu">
+              Europe
+            </option>
+            <option
+              value="kr">
+              South Korea
+            </option>
+            <option
+              value="cn">
+              China
+            </option>
+            <option
+              value="global">
+              Global
+            </option>
+          </select>
+        </span>
+      </div>
+    </div>
+    <button
+      className="button is-primary"
+      disabled={false}
+      type="submit">
+      Save
+    </button>
+  </form>
+</div>
+`;

--- a/spec/javascript/components/__snapshots__/settings.test.jsx.snap
+++ b/spec/javascript/components/__snapshots__/settings.test.jsx.snap
@@ -18,7 +18,7 @@ exports[`Settings matches snapshot 1`] = `
         onChange={[Function]}
         placeholder="Your email address"
         type="text"
-        value={undefined} />
+        value="user@example.com" />
     </div>
     <div
       className="field">
@@ -35,7 +35,7 @@ exports[`Settings matches snapshot 1`] = `
             id="platform"
             name="platform"
             onChange={[Function]}
-            value={undefined}>
+            value="xbl">
             <option
               value="" />
             <option
@@ -69,7 +69,7 @@ exports[`Settings matches snapshot 1`] = `
             id="region"
             name="region"
             onChange={[Function]}
-            value={undefined}>
+            value="eu">
             <option
               value="" />
             <option

--- a/spec/javascript/components/hero-select.test.jsx
+++ b/spec/javascript/components/hero-select.test.jsx
@@ -1,4 +1,5 @@
 import renderer from 'react-test-renderer'
+import { shallow } from 'enzyme'
 
 import HeroSelect from '../../../app/assets/javascripts/components/hero-select.jsx'
 
@@ -6,22 +7,29 @@ describe('HeroSelect', () => {
   let component = null
   let heroIDSelected = null
 
+  const hero1 = { id: 1, image: '/photo.jpg', name: 'Hanzo' }
+  const hero2 = { id: 2, image: '/pic.bmp', name: 'Ana' }
+  const props = {
+    heroes: [hero1, hero2],
+    onChange: newHeroID => { heroIDSelected = newHeroID },
+    selectedHeroID: 1,
+    disabled: false,
+    selectID: 'hero-select-dom-id',
+    isDuplicate: false
+  }
+
   beforeEach(() => {
-    const hero1 = { id: 1, image: '/photo.jpg', name: 'Hanzo' }
-    const hero2 = { id: 2, image: '/pic.bmp', name: 'Ana' }
-    const props = {
-      heroes: [hero1, hero2],
-      onChange: newHeroID => { heroIDSelected = newHeroID },
-      selectedHeroID: 1,
-      disabled: false,
-      selectID: 'hero-select-dom-id',
-      isDuplicate: false
-    }
     component = <HeroSelect {...props} />
   })
 
   test('matches snapshot', () => {
     const tree = renderer.create(component).toJSON()
     expect(tree).toMatchSnapshot()
+  })
+
+  test('can change selected hero', () => {
+    const select = shallow(component).find(`#${props.selectID}`)
+    select.simulate('change', { target: { value: hero2.id } })
+    expect(heroIDSelected).toBe(hero2.id)
   })
 })

--- a/spec/javascript/components/hero-select.test.jsx
+++ b/spec/javascript/components/hero-select.test.jsx
@@ -5,14 +5,13 @@ import HeroSelect from '../../../app/assets/javascripts/components/hero-select.j
 
 describe('HeroSelect', () => {
   let component = null
-  let heroIDSelected = null
-
   const hero1 = { id: 1, image: '/photo.jpg', name: 'Hanzo' }
+  let heroIDSelected = hero1.id
   const hero2 = { id: 2, image: '/pic.bmp', name: 'Ana' }
   const props = {
     heroes: [hero1, hero2],
     onChange: newHeroID => { heroIDSelected = newHeroID },
-    selectedHeroID: 1,
+    selectedHeroID: heroIDSelected,
     disabled: false,
     selectID: 'hero-select-dom-id',
     isDuplicate: false

--- a/spec/javascript/components/hero-select.test.jsx
+++ b/spec/javascript/components/hero-select.test.jsx
@@ -1,0 +1,27 @@
+import renderer from 'react-test-renderer'
+
+import HeroSelect from '../../../app/assets/javascripts/components/hero-select.jsx'
+
+describe('HeroSelect', () => {
+  let component = null
+  let heroIDSelected = null
+
+  beforeEach(() => {
+    const hero1 = { id: 1, image: '/photo.jpg', name: 'Hanzo' }
+    const hero2 = { id: 2, image: '/pic.bmp', name: 'Ana' }
+    const props = {
+      heroes: [hero1, hero2],
+      onChange: newHeroID => { heroIDSelected = newHeroID },
+      selectedHeroID: 1,
+      disabled: false,
+      selectID: 'hero-select-dom-id',
+      isDuplicate: false
+    }
+    component = <HeroSelect {...props} />
+  })
+
+  test('matches snapshot', () => {
+    const tree = renderer.create(component).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/spec/javascript/components/player-select.test.jsx
+++ b/spec/javascript/components/player-select.test.jsx
@@ -9,11 +9,15 @@ describe('PlayerSelect', () => {
   const player2 = { id: 2, name: 'Jimmy' }
   let selectedPlayerID = player1.id
   let wasEditPlayerCalled = false
+  let savedName = null
   const props = {
     inputID: 'input-dom-id',
     playerID: selectedPlayerID,
     players: [player1, player2],
-    onChange: newPlayerID => { selectedPlayerID = newPlayerID },
+    onChange: (newPlayerID, newName) => {
+      selectedPlayerID = newPlayerID
+      savedName = newName
+    },
     label: 'Player 1 selection',
     editPlayer: () => { wasEditPlayerCalled = true },
     disabled: false
@@ -43,5 +47,13 @@ describe('PlayerSelect', () => {
     select.simulate('change', { target: { value: 'new' } })
 
     expect(rendered.find(`#${props.inputID}`).length).toBe(1)
+  })
+
+  test('can update name of existing player', () => {
+    const rendered = shallow(component)
+    const button = rendered.find('.edit-player-button')
+    expect(button.length).toBe(1)
+    button.simulate('click', { currentTarget: { blur: () => {} } })
+    expect(wasEditPlayerCalled).toBe(true)
   })
 })

--- a/spec/javascript/components/player-select.test.jsx
+++ b/spec/javascript/components/player-select.test.jsx
@@ -1,4 +1,5 @@
 import renderer from 'react-test-renderer'
+import { shallow } from 'enzyme'
 
 import PlayerSelect from '../../../app/assets/javascripts/components/player-select.jsx'
 
@@ -25,5 +26,11 @@ describe('PlayerSelect', () => {
   test('matches snapshot', () => {
     const tree = renderer.create(component).toJSON()
     expect(tree).toMatchSnapshot()
+  })
+
+  test('can change selected player', () => {
+    const select = shallow(component).find('select')
+    select.simulate('change', { target: { value: player2.id } })
+    expect(selectedPlayerID).toBe(player2.id)
   })
 })

--- a/spec/javascript/components/player-select.test.jsx
+++ b/spec/javascript/components/player-select.test.jsx
@@ -1,0 +1,29 @@
+import renderer from 'react-test-renderer'
+
+import PlayerSelect from '../../../app/assets/javascripts/components/player-select.jsx'
+
+describe('PlayerSelect', () => {
+  let component = null
+  const player1 = { id: 1, name: 'Sally' }
+  const player2 = { id: 2, name: 'Jimmy' }
+  let selectedPlayerID = player1.id
+  let wasEditPlayerCalled = false
+  const props = {
+    inputID: 'input-dom-id',
+    playerID: selectedPlayerID,
+    players: [player1, player2],
+    onChange: newPlayerID => { selectedPlayerID = newPlayerID },
+    label: 'Player 1 selection',
+    editPlayer: () => { wasEditPlayerCalled = true },
+    disabled: false
+  }
+
+  beforeEach(() => {
+    component = <PlayerSelect {...props} />
+  })
+
+  test('matches snapshot', () => {
+    const tree = renderer.create(component).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/spec/javascript/components/player-select.test.jsx
+++ b/spec/javascript/components/player-select.test.jsx
@@ -49,11 +49,30 @@ describe('PlayerSelect', () => {
     expect(rendered.find(`#${props.inputID}`).length).toBe(1)
   })
 
-  test('can update name of existing player', () => {
+  test('can create new player', () => {
     const rendered = shallow(component)
+
+    const select = rendered.find('select')
+    select.simulate('change', { target: { value: 'new' } })
+
+    const nameField = rendered.find(`#${props.inputID}`)
+    nameField.simulate('change', { target: { value: 'Terry  ' } })
+
+    const saveButton = rendered.find('.save-new-name-button')
+    expect(saveButton.length).toBe(1)
+
+    saveButton.simulate('click', { preventDefault: () => {} })
+    expect(savedName).toBe('Terry')
+  })
+
+  test('can open modal to edit player', () => {
+    const rendered = shallow(component)
+
     const button = rendered.find('.edit-player-button')
     expect(button.length).toBe(1)
+
     button.simulate('click', { currentTarget: { blur: () => {} } })
+
     expect(wasEditPlayerCalled).toBe(true)
   })
 })

--- a/spec/javascript/components/player-select.test.jsx
+++ b/spec/javascript/components/player-select.test.jsx
@@ -33,4 +33,15 @@ describe('PlayerSelect', () => {
     select.simulate('change', { target: { value: player2.id } })
     expect(selectedPlayerID).toBe(player2.id)
   })
+
+  test('can show new player text field', () => {
+    const rendered = shallow(component)
+
+    expect(rendered.find(`#${props.inputID}`).length).toBe(0)
+
+    const select = rendered.find('select')
+    select.simulate('change', { target: { value: 'new' } })
+
+    expect(rendered.find(`#${props.inputID}`).length).toBe(1)
+  })
 })

--- a/spec/javascript/components/settings.test.jsx
+++ b/spec/javascript/components/settings.test.jsx
@@ -1,0 +1,16 @@
+import renderer from 'react-test-renderer'
+
+import Settings from '../../../app/assets/javascripts/components/settings.jsx'
+
+describe('Settings', () => {
+  let component = null
+
+  beforeEach(() => {
+    component = <Settings />
+  })
+
+  test('matches snapshot', () => {
+    const tree = renderer.create(component).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/spec/javascript/components/settings.test.jsx
+++ b/spec/javascript/components/settings.test.jsx
@@ -1,11 +1,23 @@
 import renderer from 'react-test-renderer'
 
+import mockLocalStorage from '../mocks/local-storage'
+
 import Settings from '../../../app/assets/javascripts/components/settings.jsx'
 
 describe('Settings', () => {
   let component = null
+  let store = null
 
   beforeEach(() => {
+    store = {
+      'overwatch-team-comps': JSON.stringify({
+        email: 'user@example.com',
+        region: 'eu',
+        platform: 'xbl'
+      })
+    }
+    mockLocalStorage(store)
+
     component = <Settings />
   })
 

--- a/spec/models/composition_row_spec.rb
+++ b/spec/models/composition_row_spec.rb
@@ -23,9 +23,12 @@ RSpec.describe CompositionRow, type: :model do
 
       heroes_by_segment = { @map_segment.id => [@hero1.id, @hero1.id] }
 
+      player_selections = @composition.player_selections.
+        select(:map_segment_id, :position, :player_id, :hero_id).to_a
+
       row = CompositionRow.new(number: 0, player: @player,
                                all_heroes: [@hero1, @hero2],
-                               player_selections: [ps1, ps2],
+                               player_selections: player_selections,
                                heroes_by_segment: heroes_by_segment)
 
       expect(row.duplicate?(@map_segment)).to eq(true)
@@ -37,9 +40,12 @@ RSpec.describe CompositionRow, type: :model do
 
       heroes_by_segment = { @map_segment.id => [@hero1.id] }
 
+      player_selections = @composition.player_selections.
+        select(:map_segment_id, :position, :player_id, :hero_id).to_a
+
       row = CompositionRow.new(number: 0, player: @player,
                                all_heroes: [@hero1, @hero2],
-                               player_selections: [ps1],
+                               player_selections: player_selections,
                                heroes_by_segment: heroes_by_segment)
 
       expect(row.duplicate?(@map_segment)).to eq(false)
@@ -55,9 +61,12 @@ RSpec.describe CompositionRow, type: :model do
 
       heroes_by_segment = { @map_segment.id => [@hero1.id, @hero2.id] }
 
+      player_selections = @composition.player_selections.
+        select(:map_segment_id, :position, :player_id, :hero_id).to_a
+
       row = CompositionRow.new(number: 0, player: @player,
                                all_heroes: [@hero1, @hero2],
-                               player_selections: [ps1, ps2],
+                               player_selections: player_selections,
                                heroes_by_segment: heroes_by_segment)
 
       expect(row.duplicate?(@map_segment)).to eq(false)

--- a/spec/models/composition_row_spec.rb
+++ b/spec/models/composition_row_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe CompositionRow, type: :model do
+  before(:each) do
+    @map = create(:map)
+    @composition = create(:composition, map: @map)
+    @player = create(:player, creator: @composition.user)
+    @comp_player = create(:composition_player, player: @player,
+                          composition: @composition)
+    @hero1 = create(:hero, name: 'McCree')
+    @hero2 = create(:hero, name: 'Widowmaker')
+    @map_segment = create(:map_segment, map: @map)
+  end
+
+  describe '#duplicate?' do
+    it 'returns true when a duplicate exists for given segment' do
+      # Player selection for this player:
+      ps1 = create(:player_selection, composition_player: @comp_player,
+                   map_segment: @map_segment, hero: @hero1)
+
+      # Player selection for another player:
+      ps2 = create(:player_selection, map_segment: @map_segment, hero: @hero1)
+
+      heroes_by_segment = { @map_segment.id => [@hero1.id, @hero1.id] }
+
+      row = CompositionRow.new(number: 0, player: @player,
+                               all_heroes: [@hero1, @hero2],
+                               player_selections: [ps1, ps2],
+                               heroes_by_segment: heroes_by_segment)
+
+      expect(row.duplicate?(@map_segment)).to eq(true)
+    end
+
+    it 'returns false when no hero is selected for that segment and player' do
+      # Player selection for another player:
+      ps1 = create(:player_selection, map_segment: @map_segment, hero: @hero1)
+
+      heroes_by_segment = { @map_segment.id => [@hero1.id] }
+
+      row = CompositionRow.new(number: 0, player: @player,
+                               all_heroes: [@hero1, @hero2],
+                               player_selections: [ps1],
+                               heroes_by_segment: heroes_by_segment)
+
+      expect(row.duplicate?(@map_segment)).to eq(false)
+    end
+
+    it 'returns false when no duplicate exists for that segment' do
+      # Player selection for this player:
+      ps1 = create(:player_selection, composition_player: @comp_player,
+                   map_segment: @map_segment, hero: @hero1)
+
+      # Player selection for another player:
+      ps2 = create(:player_selection, map_segment: @map_segment, hero: @hero2)
+
+      heroes_by_segment = { @map_segment.id => [@hero1.id, @hero2.id] }
+
+      row = CompositionRow.new(number: 0, player: @player,
+                               all_heroes: [@hero1, @hero2],
+                               player_selections: [ps1, ps2],
+                               heroes_by_segment: heroes_by_segment)
+
+      expect(row.duplicate?(@map_segment)).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #98 by highlighting in red when the same hero is picked more than once for a given map segment:

<img width="817" alt="team_composition_form_-_overwatch_team_comps" src="https://cloud.githubusercontent.com/assets/82317/24840032/42430a1c-1d2b-11e7-8fd9-af8e3d999d20.png">

This also adds more JavaScript and Ruby tests to improve test coverage.