### PR TITLE
Allow saving composition notes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,6 @@ gem 'font-awesome-rails', '~> 4.7.0.1'
 
 # For URL slugs
 gem 'friendly_id', '~> 5.2.0'
+
+# For Markdown parsing
+gem 'redcarpet', '~> 3.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,7 @@ GEM
       execjs
       railties (>= 3.2)
       tilt
+    redcarpet (3.4.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
     rspec-core (3.5.4)
@@ -264,6 +265,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.0.2)
   react-rails (~> 1.10.0)
+  redcarpet (~> 3.4.0)
   rspec-rails (~> 3.5.0)
   sass-rails (~> 5.0)
   spring
@@ -273,4 +275,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.11.2
+   1.15.1

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -1,5 +1,6 @@
 import AllowDuplicatesCheckbox from './allow-duplicates-checkbox.jsx'
 import CompositionFormHeader from './composition-form-header.jsx'
+import CompositionNotes from './composition-notes.jsx'
 import EditPlayerSelectionRow from './edit-player-selection-row.jsx'
 import MapSegmentHeader from './map-segment-header.jsx'
 import PlayerEditModal from './player-edit-modal.jsx'
@@ -34,7 +35,7 @@ export default class CompositionForm extends React.Component {
   }
 
   onCompositionFetchError(error) {
-    console.error('failed to load composition data', error)
+    console.error('failed to load composition data for form', error)
     this.setState({ isRequestOut: false })
   }
 
@@ -69,13 +70,6 @@ export default class CompositionForm extends React.Component {
         then(newComp => this.onCompositionLoaded(newComp)).
         catch(err => this.onCompositionSaveError(err))
     })
-  }
-
-  onCompositionNotesChange(event) {
-    // TODO: actually POST this to the server to save the value,
-    // but not as the user types because we don't want a request
-    // going for every keystroke
-    this.setState({ notes: event.target.value })
   }
 
   onPlayerSelected(playerID, playerName, position) {
@@ -329,27 +323,10 @@ export default class CompositionForm extends React.Component {
               </tr>
             </tbody>
           </table>
-          <div className="composition-notes-wrapper">
-            <label
-              htmlFor="composition_notes"
-              className="label notes-label small-fat-header"
-            >Notes</label>
-            <textarea
-              id="composition_notes"
-              className="textarea"
-              disabled={isRequestOut}
-              placeholder="Notes for this team composition"
-              value={notes || ''}
-              onChange={e => this.onCompositionNotesChange(e)}
-            />
-            <p>
-              <a
-                href="https://daringfireball.net/projects/markdown/syntax"
-                target="_blank"
-                rel="noopener noreferrer"
-              >Markdown supported</a>.
-            </p>
-          </div>
+          <CompositionNotes
+            notes={notes}
+            isRequestOut={isRequestOut}
+          />
         </div>
         <PlayerEditModal
           playerID={editingPlayerID}

--- a/app/assets/javascripts/components/composition-form.jsx
+++ b/app/assets/javascripts/components/composition-form.jsx
@@ -72,6 +72,25 @@ export default class CompositionForm extends React.Component {
     })
   }
 
+  onCompositionNotesChange(notes) {
+    const { id, mapID } = this.state
+    const api = new OverwatchTeamCompsApi()
+
+    const body = {
+      notes,
+      map_id: mapID
+    }
+    if (id) {
+      body.composition_id = id
+    }
+
+    this.setState({ isRequestOut: true }, () => {
+      api.saveComposition(body).
+        then(newComp => this.onCompositionLoaded(newComp)).
+        catch(err => this.onCompositionSaveError(err))
+    })
+  }
+
   onPlayerSelected(playerID, playerName, position) {
     if (playerID) {
       this.updatePlayer(playerID, position)
@@ -326,6 +345,7 @@ export default class CompositionForm extends React.Component {
           <CompositionNotes
             notes={notes}
             isRequestOut={isRequestOut}
+            saveNotes={n => this.onCompositionNotesChange(n)}
           />
         </div>
         <PlayerEditModal

--- a/app/assets/javascripts/components/composition-notes.jsx
+++ b/app/assets/javascripts/components/composition-notes.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import DebounceInput from 'react-debounce-input'
+import Textarea from 'react-textarea-autosize'
 
 class CompositionNotes extends React.Component {
   onCompositionNotesChange(event) {
@@ -16,7 +17,7 @@ class CompositionNotes extends React.Component {
           className="label notes-label small-fat-header"
         >Notes</label>
         <DebounceInput
-          element="textarea"
+          element={Textarea}
           forceNotifyByEnter={false}
           debounceTimeout={500}
           id="composition_notes"

--- a/app/assets/javascripts/components/composition-notes.jsx
+++ b/app/assets/javascripts/components/composition-notes.jsx
@@ -27,7 +27,7 @@ class CompositionNotes extends React.Component {
           onChange={e => this.onCompositionNotesChange(e)}
         />
         <p className="tip">
-          <strong>Tip: </strong> include a YouTube video or Twitch clip URL to embed it.
+          <strong>Tip: </strong> include a YouTube video, Streamable video, or Twitch clip URL to embed it.
         </p>
         <p>
           <a

--- a/app/assets/javascripts/components/composition-notes.jsx
+++ b/app/assets/javascripts/components/composition-notes.jsx
@@ -1,14 +1,28 @@
 import PropTypes from 'prop-types'
-import DebounceInput from 'react-debounce-input'
 import Textarea from 'react-textarea-autosize'
 
 class CompositionNotes extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { notes: props.notes }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({ notes: nextProps.notes })
+  }
+
   onCompositionNotesChange(event) {
-    this.props.saveNotes(event.target.value)
+    this.setState({ notes: event.target.value })
+  }
+
+  saveNotes(event) {
+    event.target.blur()
+    this.props.saveNotes(this.state.notes)
   }
 
   render() {
-    const { isRequestOut, notes } = this.props
+    const { isRequestOut } = this.props
+    const { notes } = this.state
 
     return (
       <div className="composition-notes-wrapper">
@@ -16,10 +30,7 @@ class CompositionNotes extends React.Component {
           htmlFor="composition_notes"
           className="label notes-label small-fat-header"
         >Notes</label>
-        <DebounceInput
-          element={Textarea}
-          forceNotifyByEnter={false}
-          debounceTimeout={500}
+        <Textarea
           id="composition_notes"
           className="textarea"
           disabled={isRequestOut}
@@ -27,6 +38,19 @@ class CompositionNotes extends React.Component {
           value={notes || ''}
           onChange={e => this.onCompositionNotesChange(e)}
         />
+        <p>
+          <button
+            type="button"
+            disabled={isRequestOut}
+            className="button save-notes-button"
+            onClick={e => this.saveNotes(e)}
+          >
+            {isRequestOut ? (
+              <i className="fa fa-spinner fa-spin" />
+            ) : ''}
+            Save notes
+          </button>
+        </p>
         <p className="tip">
           <strong>Tip: </strong> include a YouTube video, Streamable video, Gfycat gif, or Twitch clip URL to embed it.
         </p>

--- a/app/assets/javascripts/components/composition-notes.jsx
+++ b/app/assets/javascripts/components/composition-notes.jsx
@@ -2,22 +2,12 @@ import PropTypes from 'prop-types'
 import DebounceInput from 'react-debounce-input'
 
 class CompositionNotes extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = { notes: props.notes }
-  }
-
-  componentWillReceiveProps(nextProps) {
-    this.setState({ notes: nextProps.notes })
-  }
-
   onCompositionNotesChange(event) {
     this.props.saveNotes(event.target.value)
   }
 
   render() {
-    const { isRequestOut } = this.props
-    const { notes } = this.state
+    const { isRequestOut, notes } = this.props
 
     return (
       <div className="composition-notes-wrapper">

--- a/app/assets/javascripts/components/composition-notes.jsx
+++ b/app/assets/javascripts/components/composition-notes.jsx
@@ -16,7 +16,12 @@ class CompositionNotes extends React.Component {
   }
 
   saveNotes(event) {
-    event.target.blur()
+    if (this.state.isRequestOut) {
+      return
+    }
+    if (event) {
+      event.target.blur()
+    }
     this.props.saveNotes(this.state.notes)
   }
 
@@ -37,6 +42,7 @@ class CompositionNotes extends React.Component {
           placeholder="Notes for this team composition"
           value={notes || ''}
           onChange={e => this.onCompositionNotesChange(e)}
+          onBlur={() => this.saveNotes()}
         />
         <p>
           <button

--- a/app/assets/javascripts/components/composition-notes.jsx
+++ b/app/assets/javascripts/components/composition-notes.jsx
@@ -26,6 +26,9 @@ class CompositionNotes extends React.Component {
           value={notes || ''}
           onChange={e => this.onCompositionNotesChange(e)}
         />
+        <p className="tip">
+          <strong>Tip: </strong> include a YouTube video URL to embed it.
+        </p>
         <p>
           <a
             href="https://daringfireball.net/projects/markdown/syntax"

--- a/app/assets/javascripts/components/composition-notes.jsx
+++ b/app/assets/javascripts/components/composition-notes.jsx
@@ -12,10 +12,7 @@ class CompositionNotes extends React.Component {
   }
 
   onCompositionNotesChange(event) {
-    // TODO: actually POST this to the server to save the value,
-    // but not as the user types because we don't want a request
-    // going for every keystroke
-    this.setState({ notes: event.target.value })
+    this.props.saveNotes(event.target.value)
   }
 
   render() {
@@ -53,7 +50,8 @@ class CompositionNotes extends React.Component {
 
 CompositionNotes.propTypes = {
   isRequestOut: PropTypes.bool,
-  notes: PropTypes.string
+  notes: PropTypes.string,
+  saveNotes: PropTypes.func.isRequired
 }
 
 export default CompositionNotes

--- a/app/assets/javascripts/components/composition-notes.jsx
+++ b/app/assets/javascripts/components/composition-notes.jsx
@@ -27,7 +27,7 @@ class CompositionNotes extends React.Component {
           onChange={e => this.onCompositionNotesChange(e)}
         />
         <p className="tip">
-          <strong>Tip: </strong> include a YouTube video, Streamable video, or Twitch clip URL to embed it.
+          <strong>Tip: </strong> include a YouTube video, Streamable video, Gfycat gif, or Twitch clip URL to embed it.
         </p>
         <p>
           <a

--- a/app/assets/javascripts/components/composition-notes.jsx
+++ b/app/assets/javascripts/components/composition-notes.jsx
@@ -27,7 +27,7 @@ class CompositionNotes extends React.Component {
           onChange={e => this.onCompositionNotesChange(e)}
         />
         <p className="tip">
-          <strong>Tip: </strong> include a YouTube video URL to embed it.
+          <strong>Tip: </strong> include a YouTube video or Twitch clip URL to embed it.
         </p>
         <p>
           <a

--- a/app/assets/javascripts/components/composition-notes.jsx
+++ b/app/assets/javascripts/components/composition-notes.jsx
@@ -58,7 +58,8 @@ class CompositionNotes extends React.Component {
           </button>
         </p>
         <p className="tip">
-          <strong>Tip: </strong> include a YouTube video, Streamable video, Gfycat gif, or Twitch clip URL to embed it.
+          <strong>Tip: </strong> include a YouTube video, Streamable video,
+          Gfycat gif, or Twitch clip URL to embed it.
         </p>
         <p>
           <a

--- a/app/assets/javascripts/components/composition-notes.jsx
+++ b/app/assets/javascripts/components/composition-notes.jsx
@@ -1,0 +1,59 @@
+import PropTypes from 'prop-types'
+import DebounceInput from 'react-debounce-input'
+
+class CompositionNotes extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { notes: props.notes }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({ notes: nextProps.notes })
+  }
+
+  onCompositionNotesChange(event) {
+    // TODO: actually POST this to the server to save the value,
+    // but not as the user types because we don't want a request
+    // going for every keystroke
+    this.setState({ notes: event.target.value })
+  }
+
+  render() {
+    const { isRequestOut } = this.props
+    const { notes } = this.state
+
+    return (
+      <div className="composition-notes-wrapper">
+        <label
+          htmlFor="composition_notes"
+          className="label notes-label small-fat-header"
+        >Notes</label>
+        <DebounceInput
+          element="textarea"
+          forceNotifyByEnter={false}
+          debounceTimeout={500}
+          id="composition_notes"
+          className="textarea"
+          disabled={isRequestOut}
+          placeholder="Notes for this team composition"
+          value={notes || ''}
+          onChange={e => this.onCompositionNotesChange(e)}
+        />
+        <p>
+          <a
+            href="https://daringfireball.net/projects/markdown/syntax"
+            target="_blank"
+            rel="noopener noreferrer"
+          >Markdown supported</a>.
+        </p>
+      </div>
+    )
+  }
+}
+
+CompositionNotes.propTypes = {
+  isRequestOut: PropTypes.bool,
+  notes: PropTypes.string
+}
+
+export default CompositionNotes

--- a/app/assets/javascripts/components/composition-view.jsx
+++ b/app/assets/javascripts/components/composition-view.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import renderHTML from 'react-render-html'
 
 import OverwatchTeamCompsApi from '../models/overwatch-team-comps-api'
 
@@ -152,12 +153,14 @@ class CompositionView extends React.Component {
               })}
             </tbody>
           </table>
-          <div className="composition-notes-wrapper">
-            <p>Notes:</p>
-            <div>
-              {notes}
+          {notes && notes.length > 0 ? (
+            <div className="composition-notes-wrapper">
+              <p>Notes:</p>
+              <div>
+                {renderHTML(notes)}
+              </div>
             </div>
-          </div>
+          ) : ''}
           {this.compositionDate()}
         </div>
       </div>

--- a/app/assets/javascripts/components/composition-view.jsx
+++ b/app/assets/javascripts/components/composition-view.jsx
@@ -46,7 +46,7 @@ class CompositionView extends React.Component {
 
   onCompositionFetched(composition) {
     this.setState({
-      notes: composition.notes,
+      notesHTML: composition.notesHTML,
       battletag: composition.user.battletag,
       mapSegments: composition.map.segments,
       updatedAt: composition.updatedAt,
@@ -87,7 +87,7 @@ class CompositionView extends React.Component {
 
   render() {
     const { mapName, mapSegments, name, players, selections,
-            heroes, notes, mapSlug, mapImage } = this.state
+            heroes, notesHTML, mapSlug, mapImage } = this.state
 
     if (typeof mapName === 'undefined') {
       return <p className="container">Loading...</p>
@@ -153,11 +153,11 @@ class CompositionView extends React.Component {
               })}
             </tbody>
           </table>
-          {notes && notes.length > 0 ? (
+          {notesHTML && notesHTML.length > 0 ? (
             <div className="composition-notes-wrapper">
               <p>Notes:</p>
               <div className="composition-notes">
-                {renderHTML(notes)}
+                {renderHTML(notesHTML)}
               </div>
             </div>
           ) : ''}

--- a/app/assets/javascripts/components/composition-view.jsx
+++ b/app/assets/javascripts/components/composition-view.jsx
@@ -156,7 +156,7 @@ class CompositionView extends React.Component {
           {notes && notes.length > 0 ? (
             <div className="composition-notes-wrapper">
               <p>Notes:</p>
-              <div>
+              <div className="composition-notes">
                 {renderHTML(notes)}
               </div>
             </div>

--- a/app/assets/javascripts/components/composition-view.jsx
+++ b/app/assets/javascripts/components/composition-view.jsx
@@ -15,7 +15,7 @@ const months = [
 
 class CompositionView extends React.Component {
   static onCompositionFetchError(error) {
-    console.error('failed to load composition data', error)
+    console.error('failed to load composition data for view', error)
   }
 
   constructor(props) {

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -413,3 +413,17 @@
   color: $text;
   margin-bottom: 0;
 }
+
+.save-notes-button {
+  background-color: $defend;
+  color: $white;
+  @include transition-property(background-color);
+  @include transition-duration(0.2s);
+  @include transition-timing-function(ease-in-out);
+
+  &:hover,
+  &:focus {
+    background-color: $light-defend;
+    color: $defend;
+  }
+}

--- a/app/assets/stylesheets/composition-form.scss
+++ b/app/assets/stylesheets/composition-form.scss
@@ -408,3 +408,8 @@
   font-size: 13px;
   color: $text;
 }
+
+.tip {
+  color: $text;
+  margin-bottom: 0;
+}

--- a/app/assets/stylesheets/composition-view.scss
+++ b/app/assets/stylesheets/composition-view.scss
@@ -50,3 +50,21 @@
   font-size: 12px;
   margin: 40px 0;
 }
+
+.composition-notes {
+  padding: 1.5rem;
+  background-color: $white;
+  @include box-shadow(0 2px 3px rgba(10, 10, 10, 0.1), 0 0 0 1px rgba(10, 10, 10, 0.1));
+
+  &, p {
+    color: $text;
+  }
+
+  & > *:first-child {
+    margin-top: 0;
+  }
+
+  & > *:last-child {
+    margin-bottom: 0;
+  }
+}

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -53,6 +53,10 @@
       border-color: lighten($attack, 10%);
     }
   }
+
+  .fa {
+    margin-right: 3px;
+  }
 }
 
 .button-link {

--- a/app/assets/stylesheets/typography.scss
+++ b/app/assets/stylesheets/typography.scss
@@ -19,6 +19,10 @@ strong {
   font-weight: 700;
 }
 
+em {
+  font-style: italic;
+}
+
 h1 {
   color: $text;
   font-size: 3em;

--- a/app/models/composition.rb
+++ b/app/models/composition.rb
@@ -45,6 +45,17 @@ class Composition < ApplicationRecord
     (player_pool | players).sort_by { |player| player.name.downcase }
   end
 
+  def notes_html
+    return unless notes
+
+    @notes_html ||= begin
+      renderer = Redcarpet::Render::HTML.new(filter_html: true, no_styles: true,
+                                             safe_links_only: true, with_toc_data: true)
+      markdown = Redcarpet::Markdown.new(renderer, autolink: true)
+      markdown.render(notes)
+    end
+  end
+
   def set_name
     return unless user
     return if name.present?

--- a/app/models/composition.rb
+++ b/app/models/composition.rb
@@ -49,8 +49,8 @@ class Composition < ApplicationRecord
     return unless notes
 
     @notes_html ||= begin
-      renderer = Redcarpet::Render::HTML.new(filter_html: true, no_styles: true,
-                                             safe_links_only: true, with_toc_data: true)
+      renderer = CustomMarkdownRenderer.new(filter_html: true, no_styles: true,
+                                            safe_links_only: true, with_toc_data: true)
       markdown = Redcarpet::Markdown.new(renderer, autolink: true)
       markdown.render(notes)
     end

--- a/app/models/custom_markdown_renderer.rb
+++ b/app/models/custom_markdown_renderer.rb
@@ -1,4 +1,7 @@
 class CustomMarkdownRenderer < Redcarpet::Render::HTML
+  VIDEO_WIDTH = 560
+  VIDEO_HEIGHT = 315
+
   def autolink(link, link_type)
     case link_type
       when :url then url_link(link)
@@ -9,9 +12,15 @@ class CustomMarkdownRenderer < Redcarpet::Render::HTML
   def url_link(url)
     if is_youtube_video_url?(url)
       embed_youtube_video(url)
+    elsif is_twitch_clip_url?(url)
+      embed_twitch_clip(url)
     else
       normal_link(url)
     end
+  end
+
+  def is_twitch_clip_url?(url)
+    url =~ /^(?:https?:\/\/)?(?:www\.)?clips\.twitch\.tv/i
   end
 
   def is_youtube_video_url?(url)
@@ -20,9 +29,23 @@ class CustomMarkdownRenderer < Redcarpet::Render::HTML
 
   def embed_youtube_video(url)
     uri = URI.parse(url)
-    params = uri.query.split('&').map { |str| str.split('=') }.to_h
+    params = get_url_params(uri)
     video_id = params['v'] || uri.path[1..-1]
-    %Q(<iframe width="560" height="315" src="//www.youtube.com/embed/#{video_id}?rel=0" frameborder="0" allowfullscreen></iframe>)
+    %Q(<iframe width="#{VIDEO_WIDTH}" height="#{VIDEO_HEIGHT}" src="//www.youtube.com/embed/#{video_id}?rel=0" frameborder="0" allowfullscreen></iframe>)
+  end
+
+  def embed_twitch_clip(url)
+    uri = URI.parse(url)
+    params = get_url_params(uri)
+    video_id = params['clip'] || uri.path[1..-1]
+    %Q(<iframe src="https://clips.twitch.tv/embed?clip=#{video_id}&autoplay=false&tt_medium=clips_embed" width="#{VIDEO_WIDTH}" height="#{VIDEO_HEIGHT}" frameborder="0" scrolling="no" allowfullscreen="true"></iframe>)
+  end
+
+  def get_url_params(uri)
+    query = uri.query
+    return {} unless query
+
+    query.split('&').map { |str| str.split('=') }.to_h
   end
 
   def normal_link(url)

--- a/app/models/custom_markdown_renderer.rb
+++ b/app/models/custom_markdown_renderer.rb
@@ -14,11 +14,17 @@ class CustomMarkdownRenderer < Redcarpet::Render::HTML
       embed_youtube_video(url)
     elsif is_twitch_clip_url?(url)
       embed_twitch_clip(url)
+    elsif is_gfycat_video_url?(url)
+      embed_gfycat_video(url)
     elsif is_streamable_video_url?(url)
       embed_streamable_video(url)
     else
       normal_link(url)
     end
+  end
+
+  def is_gfycat_video_url?(url)
+    url =~ /^(?:https?:\/\/)?(?:www\.)?gfycat\.com/i
   end
 
   def is_streamable_video_url?(url)
@@ -31,6 +37,14 @@ class CustomMarkdownRenderer < Redcarpet::Render::HTML
 
   def is_youtube_video_url?(url)
     url =~ /^(?:https?:\/\/)?(?:www\.)?youtu(?:\.be|be\.com)\/(?:watch\?v=)?([\w-]{10,})/i
+  end
+
+  def embed_gfycat_video(url)
+    uri = URI.parse(url)
+    parts = uri.path.split('/').reject(&:blank?)
+    video_id = parts[0]
+    video_id = parts[1] if video_id.downcase == 'ifr'
+    %Q(<iframe src="https://gfycat.com/ifr/#{video_id}" frameborder="0" scrolling="no" allowfullscreen width="#{VIDEO_WIDTH}" height="#{VIDEO_HEIGHT}"></iframe>)
   end
 
   def embed_youtube_video(url)

--- a/app/models/custom_markdown_renderer.rb
+++ b/app/models/custom_markdown_renderer.rb
@@ -14,9 +14,15 @@ class CustomMarkdownRenderer < Redcarpet::Render::HTML
       embed_youtube_video(url)
     elsif is_twitch_clip_url?(url)
       embed_twitch_clip(url)
+    elsif is_streamable_video_url?(url)
+      embed_streamable_video(url)
     else
       normal_link(url)
     end
+  end
+
+  def is_streamable_video_url?(url)
+    url =~ /^(?:https?:\/\/)?(?:www\.)?streamable\.com/i
   end
 
   def is_twitch_clip_url?(url)
@@ -39,6 +45,14 @@ class CustomMarkdownRenderer < Redcarpet::Render::HTML
     params = get_url_params(uri)
     video_id = params['clip'] || uri.path[1..-1]
     %Q(<iframe src="https://clips.twitch.tv/embed?clip=#{video_id}&autoplay=false&tt_medium=clips_embed" width="#{VIDEO_WIDTH}" height="#{VIDEO_HEIGHT}" frameborder="0" scrolling="no" allowfullscreen="true"></iframe>)
+  end
+
+  def embed_streamable_video(url)
+    uri = URI.parse(url)
+    parts = uri.path.split('/').reject(&:blank?)
+    video_id = parts[0]
+    video_id = parts[1] if video_id.downcase == 's'
+    %Q(<iframe src="https://streamable.com/s/#{video_id}" frameborder="0" width="#{VIDEO_WIDTH}" height="#{VIDEO_HEIGHT}" allowfullscreen></iframe>)
   end
 
   def get_url_params(uri)

--- a/app/models/custom_markdown_renderer.rb
+++ b/app/models/custom_markdown_renderer.rb
@@ -1,0 +1,35 @@
+class CustomMarkdownRenderer < Redcarpet::Render::HTML
+  def autolink(link, link_type)
+    case link_type
+      when :url then url_link(link)
+      when :email then email_link(link)
+    end
+  end
+
+  def url_link(url)
+    if is_youtube_video_url?(url)
+      embed_youtube_video(url)
+    else
+      normal_link(url)
+    end
+  end
+
+  def is_youtube_video_url?(url)
+    url =~ /^(?:https?:\/\/)?(?:www\.)?youtu(?:\.be|be\.com)\/(?:watch\?v=)?([\w-]{10,})/i
+  end
+
+  def embed_youtube_video(url)
+    uri = URI.parse(url)
+    params = uri.query.split('&').map { |str| str.split('=') }.to_h
+    video_id = params['v'] || uri.path[1..-1]
+    %Q(<iframe width="560" height="315" src="//www.youtube.com/embed/#{video_id}?rel=0" frameborder="0" allowfullscreen></iframe>)
+  end
+
+  def normal_link(url)
+    %Q(<a href="#{url}">#{url}</a>)
+  end
+
+  def email_link(email)
+    %Q(<a href="mailto:#{email}">#{email}</a>)
+  end
+end

--- a/app/views/compositions/show.json.jbuilder
+++ b/app/views/compositions/show.json.jbuilder
@@ -9,7 +9,8 @@ json.composition do
   json.allowDuplicates @composition.allow_duplicates?
   json.slug @composition.slug
   json.name @composition.name
-  json.notes @composition.notes_html
+  json.notes @composition.notes
+  json.notesHTML @composition.notes_html
   json.map do
     json.id @composition.map.id
     json.name @composition.map.name

--- a/app/views/compositions/show.json.jbuilder
+++ b/app/views/compositions/show.json.jbuilder
@@ -9,7 +9,7 @@ json.composition do
   json.allowDuplicates @composition.allow_duplicates?
   json.slug @composition.slug
   json.name @composition.name
-  json.notes @composition.notes
+  json.notes @composition.notes_html
   json.map do
     json.id @composition.map.id
     json.name @composition.map.name

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-dom": "^15.4.2",
     "react-render-html": "^0.2.0",
     "react-router": "^3.0.2",
+    "react-textarea-autosize": "^5.0.7",
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react": "^15.4.2",
     "react-debounce-input": "^2.4.2",
     "react-dom": "^15.4.2",
+    "react-render-html": "^0.2.0",
     "react-router": "^3.0.2",
     "whatwg-fetch": "^2.0.3"
   },

--- a/spec/javascript/components/__snapshots__/about.test.jsx.snap
+++ b/spec/javascript/components/__snapshots__/about.test.jsx.snap
@@ -5,6 +5,40 @@ exports[`About matches snapshot 1`] = `
     About
   </h1>
   <p>
+    Plan and share your Overwatch team compositions!
+  </p>
+  <h2>
+    Team Planner
+  </h2>
+  <p>
+    Plan which heroes your team will play on every point of every map. Share your team composition easily with friends. All team plans are saved for future editing.
+  </p>
+  <h2>
+    Hero Skill Rating
+  </h2>
+  <p>
+    You and your teammates can rank how skilled you are with each hero. This links to the Team Planner, so that it becomes easier to plan ‘who can play what’ on each map.
+  </p>
+  <h2>
+    Instructions
+  </h2>
+  <h2>
+    Contact Us
+  </h2>
+  <p>
+    Thank you for using the Overwatch Planning Tool! Our hope is that this will help promote teamwork and make the game more enjoyable for casual groups of friends as well as professional competitive teams.
+  </p>
+  <p>
+    We would love to hear from you! Have questions? Feedback? Requests for new features? Business inquiries? Send us an email at
+    <code>
+       contact@owplanningtool.com
+    </code>
+    .
+  </p>
+  <h2>
+    Thanks
+  </h2>
+  <p>
     Thanks to Blizzard for Overwatch. 
     <i
       aria-hidden="true"


### PR DESCRIPTION
This fixes #32:

- You can now save notes about your team comp.
- You can paste in links to Gfycat, Twitch, YouTube, and Streamable videos and they will be automatically embedded.
- The notes field grows as you add new lines.
- You can use basic Markdown to add custom links, headers, boldface/italic/underline, etc. formatting to your notes.

**The editor:**

<img width="752" alt="team_composition_form_-_overwatch_team_comps" src="https://user-images.githubusercontent.com/82317/27772914-b526eb8c-5f31-11e7-9c56-18488e322fa2.png">

----

**The result:**

<img width="699" alt="clearly_the_best_-_hanamura_-_overwatch_team_comps" src="https://user-images.githubusercontent.com/82317/27772931-1944e2ae-5f32-11e7-87ba-8e45fe63cce8.png">

/cc @RobThePM 