### PR TITLE
Refactor HeroSelect, MapSelect to use a common SelectMenu component

### DIFF
--- a/app/assets/javascripts/components/hero-select.jsx
+++ b/app/assets/javascripts/components/hero-select.jsx
@@ -1,120 +1,56 @@
 import PropTypes from 'prop-types'
-import onClickOutside from 'react-onclickoutside'
+
+import SelectMenu from './select-menu.jsx'
 
 class HeroSelect extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = { isOpen: false }
-  }
-
-  onMenuItemClick(event, heroID) {
-    event.preventDefault()
-    event.target.blur()
-    if (this.props.disabled) {
-      return
-    }
-    this.setState({ isOpen: false }, () => {
-      this.props.onChange(heroID)
-    })
-  }
-
-  handleClickOutside() {
-    if (this.state.isOpen) {
-      this.setState({ isOpen: false })
-    }
-  }
-
-  heroPortrait() {
-    const { heroes, selectedHeroID } = this.props
-    if (typeof selectedHeroID !== 'number') {
-      return (
-        <span className="hero-portrait-placeholder" />
-      )
-    }
-    const hero = heroes.filter(h => h.id === selectedHeroID)[0]
-    return (
-      <img
-        src={hero.image}
-        alt={hero.name}
-        className="hero-portrait"
-      />
-    )
-  }
-
-  menuClass() {
-    const classes = ['menu']
-    if (this.props.disabled) {
-      classes.push('is-disabled')
-    }
-    return classes.join(' ')
-  }
-
-  isFilled() {
-    return typeof this.props.selectedHeroID === 'number'
-  }
-
   containerClass() {
-    const classes = ['hero-select-container menu-container']
-    if (!this.isFilled()) {
+    const classes = ['hero-select-container']
+    if (typeof this.props.selectedHeroID !== 'number') {
       classes.push('not-filled')
     }
     if (this.props.isDuplicate) {
       classes.push('is-duplicate')
     }
-    if (this.state.isOpen) {
-      classes.push('open')
-    }
     return classes.join(' ')
   }
 
-  toggleMenuOpen(event) {
-    event.target.blur()
-    this.setState({ isOpen: !this.state.isOpen })
-  }
-
   render() {
-    const { heroes, selectedHeroID, disabled } = this.props
-    const isFilled = this.isFilled()
+    const { heroes, selectedHeroID, disabled, onChange } = this.props
+    const isFilled = typeof selectedHeroID === 'number'
     let selectedHeroName = 'Hero'
+    let heroPortrait = <span className="hero-portrait-placeholder" />
     if (isFilled) {
-      selectedHeroName = heroes.filter(h => h.id === selectedHeroID)[0].name
+      const selectedHero = heroes.filter(h => h.id === selectedHeroID)[0]
+      selectedHeroName = selectedHero.name
+      heroPortrait = (
+        <img
+          src={selectedHero.image}
+          alt={selectedHeroName}
+          className="hero-portrait"
+        />
+      )
     }
+
     return (
-      <div className={this.containerClass()}>
-        <button
-          type="button"
-          disabled={disabled}
-          className={`button menu-toggle ${disabled ? 'is-disabled' : ''}`}
-          onClick={e => this.toggleMenuOpen(e)}
-        >
-          {this.heroPortrait()} {selectedHeroName} <i
-            aria-hidden="true"
-            className="fa fa-caret-down"
-          />
-        </button>
-        <div className={this.menuClass()}>
-          {heroes.map(hero => {
-            const isSelected = hero.id === selectedHeroID
-            return (
-              <button
-                key={hero.id}
-                className={`hero-${hero.slug} menu-item button ${isSelected ? 'is-selected' : ''}`}
-                onClick={e => this.onMenuItemClick(e, hero.id)}
-              >
-                <img
-                  src={hero.image}
-                  alt={hero.name}
-                  className="hero-portrait"
-                />
-                {hero.name}
-                {isSelected ? (
-                  <i aria-hidden="true" className="fa fa-check menu-item-selected-indicator" />
-                ) : ''}
-              </button>
-            )
-          })}
-        </div>
-      </div>
+      <SelectMenu
+        items={heroes}
+        disabled={disabled}
+        selectedItemID={selectedHeroID}
+        onChange={val => onChange(val)}
+        containerClass={() => this.containerClass()}
+        menuToggleContents={() => <span>{heroPortrait} {selectedHeroName}</span>}
+        menuItemClass={hero => `hero-${hero.slug}`}
+        menuItemContent={(hero, isSelected) => (
+          <span className={isSelected ? 'with-selected' : ''}>
+            <img
+              src={hero.image}
+              alt={hero.name}
+              className="hero-portrait"
+            />
+            <span className="css-truncate">{hero.name}</span>
+          </span>
+        )}
+      />
     )
   }
 }
@@ -127,4 +63,4 @@ HeroSelect.propTypes = {
   isDuplicate: PropTypes.bool
 }
 
-export default process.env.NODE_ENV === 'test' ? HeroSelect : onClickOutside(HeroSelect)
+export default HeroSelect

--- a/app/assets/javascripts/components/map-select.jsx
+++ b/app/assets/javascripts/components/map-select.jsx
@@ -1,91 +1,34 @@
 import PropTypes from 'prop-types'
-import onClickOutside from 'react-onclickoutside'
 
-class MapSelect extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = { isOpen: false }
-  }
+import SelectMenu from './select-menu.jsx'
 
-  onMapChange(event) {
-    this.props.onChange(event.target.value)
-  }
+const MapSelect = function(props) {
+  const { selectedMapID, disabled, maps, onChange } = props
+  const selectedMap = maps.filter(m => m.id === selectedMapID)[0]
 
-  onMenuItemClick(event, mapID) {
-    event.preventDefault()
-    event.target.blur()
-    if (this.props.disabled) {
-      return
-    }
-    this.setState({ isOpen: false }, () => {
-      this.props.onChange(mapID)
-    })
-  }
-
-  containerClass() {
-    const classes = ['map-select-container menu-container']
-    if (this.state.isOpen) {
-      classes.push('open')
-    }
-    return classes.join(' ')
-  }
-
-  handleClickOutside() {
-    if (this.state.isOpen) {
-      this.setState({ isOpen: false })
-    }
-  }
-
-  menuClass() {
-    const classes = ['menu']
-    if (this.props.disabled) {
-      classes.push('is-disabled')
-    }
-    return classes.join(' ')
-  }
-
-  toggleMenuOpen(event) {
-    event.target.blur()
-    this.setState({ isOpen: !this.state.isOpen })
-  }
-
-  render() {
-    const { selectedMapID, disabled, maps } = this.props
-    const selectedMapName = maps.filter(m => m.id === selectedMapID)[0].name
-
-    return (
-      <div className={this.containerClass()}>
-        <button
-          type="button"
-          disabled={disabled}
-          className={`button menu-toggle ${disabled ? 'is-disabled' : ''}`}
-          onClick={e => this.toggleMenuOpen(e)}
-        >
+  return (
+    <SelectMenu
+      items={maps}
+      disabled={disabled}
+      selectedItemID={selectedMapID}
+      onChange={val => onChange(val)}
+      containerClass={() => 'map-select-container'}
+      menuToggleContents={() => (
+        <span>
           <i
             className="fa fa-map-marker"
             aria-hidden="true"
-          /> {selectedMapName} <i className="fa fa-caret-down" aria-hidden="true" />
-        </button>
-        <div className={this.menuClass()}>
-          {maps.map(map => {
-            const isSelected = map.id === selectedMapID
-            return (
-              <button
-                key={map.id}
-                className={`map-${map.slug} menu-item button ${isSelected ? 'is-selected' : ''}`}
-                onClick={e => this.onMenuItemClick(e, map.id)}
-              >
-                {map.name}
-                {isSelected ? (
-                  <i aria-hidden="true" className="fa fa-check menu-item-selected-indicator" />
-                ) : ''}
-              </button>
-            )
-          })}
-        </div>
-      </div>
-    )
-  }
+          /> {selectedMap.name}
+        </span>
+      )}
+      menuItemClass={map => `map-${map.slug}`}
+      menuItemContent={(map, isSelected) => (
+        <span className={isSelected ? 'with-selected' : ''}>
+          {map.name}
+        </span>
+      )}
+    />
+  )
 }
 
 MapSelect.propTypes = {
@@ -95,4 +38,4 @@ MapSelect.propTypes = {
   onChange: PropTypes.func.isRequired
 }
 
-export default process.env.NODE_ENV === 'test' ? MapSelect : onClickOutside(MapSelect)
+export default MapSelect

--- a/app/assets/javascripts/components/map-select.jsx
+++ b/app/assets/javascripts/components/map-select.jsx
@@ -24,7 +24,7 @@ const MapSelect = function(props) {
       menuItemClass={map => `map-${map.slug}`}
       menuItemContent={(map, isSelected) => (
         <span className={isSelected ? 'with-selected' : ''}>
-          {map.name}
+          <span className="css-truncate">{map.name}</span>
         </span>
       )}
     />

--- a/app/assets/javascripts/components/select-menu.jsx
+++ b/app/assets/javascripts/components/select-menu.jsx
@@ -101,14 +101,34 @@ class SelectMenu extends React.Component {
 }
 
 SelectMenu.propTypes = {
+  // List of objects for the menu. Each should have an `id` property.
   items: PropTypes.array.isRequired,
+
+  // Callback when a new item from the menu is chosen.
   onChange: PropTypes.func.isRequired,
+
+  // ID of one of the `items` in the menu.
   selectedItemID: PropTypes.number,
+
+  // Whether the menu should be disabled or not.
   disabled: PropTypes.bool.isRequired,
+
+  // Function returning a string to be applied to the menu.
   menuClass: PropTypes.func,
+
+  // Function returning a string to be applied to the container.
   containerClass: PropTypes.func,
+
+  // Function returning an element that should appear in the button
+  // that toggles the menu open/closed.
   menuToggleContents: PropTypes.func.isRequired,
+
+  // Function that returns a string for the CSS class for a given
+  // menu item.
   menuItemClass: PropTypes.func,
+
+  // Function returning an element that should appear in a given
+  // menu item's button.
   menuItemContent: PropTypes.func.isRequired
 }
 

--- a/app/assets/javascripts/components/select-menu.jsx
+++ b/app/assets/javascripts/components/select-menu.jsx
@@ -1,0 +1,107 @@
+import PropTypes from 'prop-types'
+import onClickOutside from 'react-onclickoutside'
+
+class SelectMenu extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { isOpen: false }
+  }
+
+  onMenuItemClick(event, newValue) {
+    event.preventDefault()
+    event.target.blur()
+    if (this.props.disabled) {
+      return
+    }
+    this.setState({ isOpen: false }, () => {
+      this.props.onChange(newValue)
+    })
+  }
+
+  handleClickOutside() {
+    if (this.state.isOpen) {
+      this.setState({ isOpen: false })
+    }
+  }
+
+  menuClass() {
+    const classes = ['menu']
+    if (this.props.disabled) {
+      classes.push('is-disabled')
+    }
+    return classes.join(' ')
+  }
+
+  containerClass() {
+    const classes = ['menu-container']
+    if (this.state.isOpen) {
+      classes.push('open')
+    }
+    return classes.join(' ')
+  }
+
+  menuItemClass(item, isSelected) {
+    return `menu-item button ${isSelected ? 'is-selected' : ''}`
+  }
+
+  // Override in child classes
+  menuItemContent() {
+    return <span>Item</span>
+  }
+
+  // Override in child classes
+  menuToggleContents() {
+    return <span>Menu</span>
+  }
+
+  toggleMenuOpen(event) {
+    event.target.blur()
+    this.setState({ isOpen: !this.state.isOpen })
+  }
+
+  render() {
+    const { items, selectedItemID, disabled } = this.props
+
+    return (
+      <div className={this.containerClass()}>
+        <button
+          type="button"
+          disabled={disabled}
+          className={`button menu-toggle ${disabled ? 'is-disabled' : ''}`}
+          onClick={e => this.toggleMenuOpen(e)}
+        >
+          {this.menuToggleContents()} <i
+            aria-hidden="true"
+            className="fa fa-caret-down"
+          />
+        </button>
+        <div className={this.menuClass()}>
+          {items.map(item => {
+            const isSelected = item.id === selectedItemID
+            return (
+              <button
+                key={item.id}
+                className={this.menuItemClass(item, isSelected)}
+                onClick={e => this.onMenuItemClick(e, item.id)}
+              >
+                {this.menuItemContent()}
+                {isSelected ? (
+                  <i aria-hidden="true" className="fa fa-check menu-item-selected-indicator" />
+                ) : ''}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+}
+
+SelectMenu.propTypes = {
+  items: PropTypes.array.isRequired,
+  onChange: PropTypes.func.isRequired,
+  selectedItemID: PropTypes.number,
+  disabled: PropTypes.bool.isRequired
+}
+
+export default process.env.NODE_ENV === 'test' ? SelectMenu : onClickOutside(SelectMenu)

--- a/app/assets/javascripts/components/select-menu.jsx
+++ b/app/assets/javascripts/components/select-menu.jsx
@@ -29,6 +29,9 @@ class SelectMenu extends React.Component {
     if (this.props.disabled) {
       classes.push('is-disabled')
     }
+    if (this.props.menuClass) {
+      classes.push(this.props.menuClass())
+    }
     return classes.join(' ')
   }
 
@@ -37,21 +40,21 @@ class SelectMenu extends React.Component {
     if (this.state.isOpen) {
       classes.push('open')
     }
+    if (this.props.containerClass) {
+      classes.push(this.props.containerClass())
+    }
     return classes.join(' ')
   }
 
   menuItemClass(item, isSelected) {
-    return `menu-item button ${isSelected ? 'is-selected' : ''}`
-  }
-
-  // Override in child classes
-  menuItemContent() {
-    return <span>Item</span>
-  }
-
-  // Override in child classes
-  menuToggleContents() {
-    return <span>Menu</span>
+    const classes = ['menu-item button']
+    if (isSelected) {
+      classes.push('is-selected')
+    }
+    if (this.props.menuItemClass) {
+      classes.push(this.props.menuItemClass(item, isSelected))
+    }
+    return classes.join(' ')
   }
 
   toggleMenuOpen(event) {
@@ -60,17 +63,17 @@ class SelectMenu extends React.Component {
   }
 
   render() {
-    const { items, selectedItemID, disabled } = this.props
+    const { items, selectedItemID, disabled, menuToggleContents } = this.props
 
     return (
       <div className={this.containerClass()}>
         <button
           type="button"
           disabled={disabled}
-          className={`button menu-toggle ${disabled ? 'is-disabled' : ''}`}
+          className={`button menu-toggle${disabled ? ' is-disabled' : ''}`}
           onClick={e => this.toggleMenuOpen(e)}
         >
-          {this.menuToggleContents()} <i
+          {menuToggleContents()} <i
             aria-hidden="true"
             className="fa fa-caret-down"
           />
@@ -84,7 +87,7 @@ class SelectMenu extends React.Component {
                 className={this.menuItemClass(item, isSelected)}
                 onClick={e => this.onMenuItemClick(e, item.id)}
               >
-                {this.menuItemContent()}
+                {this.props.menuItemContent(item, isSelected)}
                 {isSelected ? (
                   <i aria-hidden="true" className="fa fa-check menu-item-selected-indicator" />
                 ) : ''}
@@ -101,7 +104,12 @@ SelectMenu.propTypes = {
   items: PropTypes.array.isRequired,
   onChange: PropTypes.func.isRequired,
   selectedItemID: PropTypes.number,
-  disabled: PropTypes.bool.isRequired
+  disabled: PropTypes.bool.isRequired,
+  menuClass: PropTypes.func,
+  containerClass: PropTypes.func,
+  menuToggleContents: PropTypes.func.isRequired,
+  menuItemClass: PropTypes.func,
+  menuItemContent: PropTypes.func.isRequired
 }
 
 export default process.env.NODE_ENV === 'test' ? SelectMenu : onClickOutside(SelectMenu)

--- a/app/assets/stylesheets/menus.scss
+++ b/app/assets/stylesheets/menus.scss
@@ -86,8 +86,13 @@ button.dropdown-item {
     @include display-flex(flex);
     @include flex-grow(1);
     @include align-items(center);
-    padding: 0;
+    padding: 0 13px 0 0;
     background-color: inherit;
+
+    > span {
+      @include display-flex(flex);
+      @include align-items(center);
+    }
 
     &.is-disabled {
       color: $soft-text;
@@ -106,6 +111,16 @@ button.dropdown-item {
 
   &.menu-item {
     padding: 0 10px;
+
+    .with-selected {
+      padding-right: 16px;
+    }
+
+    > span {
+      @include display-flex(flex);
+      @include align-items(center);
+      max-width: 100%;
+    }
   }
 }
 

--- a/app/assets/stylesheets/typography.scss
+++ b/app/assets/stylesheets/typography.scss
@@ -62,3 +62,12 @@ h4 {
   font-weight: 700;
   letter-spacing: 1px;
 }
+
+.css-truncate {
+  overflow: hidden;
+  max-width: 100%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
+  text-align: left;
+}

--- a/spec/javascript/components/__snapshots__/hero-select.test.jsx.snap
+++ b/spec/javascript/components/__snapshots__/hero-select.test.jsx.snap
@@ -1,17 +1,19 @@
 exports[`HeroSelect matches snapshot 1`] = `
 <div
-  className="hero-select-container menu-container">
+  className="menu-container hero-select-container">
   <button
-    className="button menu-toggle "
+    className="button menu-toggle"
     disabled={false}
     onClick={[Function]}
     type="button">
-    <img
-      alt="Hanzo"
-      className="hero-portrait"
-      src="/photo.jpg" />
-     
-    Hanzo
+    <span>
+      <img
+        alt="Hanzo"
+        className="hero-portrait"
+        src="/photo.jpg" />
+       
+      Hanzo
+    </span>
      
     <i
       aria-hidden="true"
@@ -20,25 +22,37 @@ exports[`HeroSelect matches snapshot 1`] = `
   <div
     className="menu">
     <button
-      className="hero-hanzo menu-item button is-selected"
+      className="menu-item button is-selected hero-hanzo"
       onClick={[Function]}>
-      <img
-        alt="Hanzo"
-        className="hero-portrait"
-        src="/photo.jpg" />
-      Hanzo
+      <span
+        className="with-selected">
+        <img
+          alt="Hanzo"
+          className="hero-portrait"
+          src="/photo.jpg" />
+        <span
+          className="css-truncate">
+          Hanzo
+        </span>
+      </span>
       <i
         aria-hidden="true"
         className="fa fa-check menu-item-selected-indicator" />
     </button>
     <button
-      className="hero-ana menu-item button "
+      className="menu-item button hero-ana"
       onClick={[Function]}>
-      <img
-        alt="Ana"
-        className="hero-portrait"
-        src="/pic.bmp" />
-      Ana
+      <span
+        className="">
+        <img
+          alt="Ana"
+          className="hero-portrait"
+          src="/pic.bmp" />
+        <span
+          className="css-truncate">
+          Ana
+        </span>
+      </span>
       
     </button>
   </div>

--- a/spec/javascript/components/__snapshots__/map-select.test.jsx.snap
+++ b/spec/javascript/components/__snapshots__/map-select.test.jsx.snap
@@ -1,16 +1,18 @@
 exports[`MapSelect matches snapshot 1`] = `
 <div
-  className="map-select-container menu-container">
+  className="menu-container map-select-container">
   <button
-    className="button menu-toggle "
+    className="button menu-toggle"
     disabled={false}
     onClick={[Function]}
     type="button">
-    <i
-      aria-hidden="true"
-      className="fa fa-map-marker" />
-     
-    Dorado
+    <span>
+      <i
+        aria-hidden="true"
+        className="fa fa-map-marker" />
+       
+      Dorado
+    </span>
      
     <i
       aria-hidden="true"
@@ -19,17 +21,29 @@ exports[`MapSelect matches snapshot 1`] = `
   <div
     className="menu">
     <button
-      className="map-dorado menu-item button is-selected"
+      className="menu-item button is-selected map-dorado"
       onClick={[Function]}>
-      Dorado
+      <span
+        className="with-selected">
+        <span
+          className="css-truncate">
+          Dorado
+        </span>
+      </span>
       <i
         aria-hidden="true"
         className="fa fa-check menu-item-selected-indicator" />
     </button>
     <button
-      className="map-eichenwalde menu-item button "
+      className="menu-item button map-eichenwalde"
       onClick={[Function]}>
-      Eichenwalde
+      <span
+        className="">
+        <span
+          className="css-truncate">
+          Eichenwalde
+        </span>
+      </span>
       
     </button>
   </div>

--- a/spec/javascript/components/__snapshots__/select-menu.test.jsx.snap
+++ b/spec/javascript/components/__snapshots__/select-menu.test.jsx.snap
@@ -1,0 +1,47 @@
+exports[`SelectMenu matches snapshot 1`] = `
+<div
+  className="menu-container custom-container-class">
+  <button
+    className="button menu-toggle"
+    disabled={false}
+    onClick={[Function]}
+    type="button">
+    <span>
+      Menu
+    </span>
+     
+    <i
+      aria-hidden="true"
+      className="fa fa-caret-down" />
+  </button>
+  <div
+    className="menu custom-menu-class">
+    <button
+      className="menu-item button is-selected item-1"
+      onClick={[Function]}>
+      <span
+        className="with-selected">
+        <span
+          className="css-truncate">
+          First item
+        </span>
+      </span>
+      <i
+        aria-hidden="true"
+        className="fa fa-check menu-item-selected-indicator" />
+    </button>
+    <button
+      className="menu-item button item-2"
+      onClick={[Function]}>
+      <span
+        className="">
+        <span
+          className="css-truncate">
+          Second item
+        </span>
+      </span>
+      
+    </button>
+  </div>
+</div>
+`;

--- a/spec/javascript/components/hero-select.test.jsx
+++ b/spec/javascript/components/hero-select.test.jsx
@@ -1,5 +1,4 @@
 import renderer from 'react-test-renderer'
-import { shallow } from 'enzyme'
 
 import HeroSelect from '../../../app/assets/javascripts/components/hero-select.jsx'
 
@@ -23,20 +22,5 @@ describe('HeroSelect', () => {
   test('matches snapshot', () => {
     const tree = renderer.create(component).toJSON()
     expect(tree).toMatchSnapshot()
-  })
-
-  test('can change selected hero', () => {
-    const rendered = shallow(component)
-
-    const select = rendered.find('.menu-toggle')
-    select.simulate('click', { target: { blur: () => {} } })
-
-    const newHeroButton = rendered.find('.menu-item.hero-ana')
-    newHeroButton.simulate('click', {
-      preventDefault: () => {},
-      target: { blur: () => {} }
-    })
-
-    expect(heroIDSelected).toBe(hero2.id)
   })
 })

--- a/spec/javascript/components/map-select.test.jsx
+++ b/spec/javascript/components/map-select.test.jsx
@@ -1,5 +1,4 @@
 import renderer from 'react-test-renderer'
-import { shallow } from 'enzyme'
 
 import MapSelect from '../../../app/assets/javascripts/components/map-select.jsx'
 
@@ -36,20 +35,5 @@ describe('MapSelect', () => {
   test('matches snapshot', () => {
     const tree = renderer.create(component).toJSON()
     expect(tree).toMatchSnapshot()
-  })
-
-  test('can change selected map', () => {
-    const rendered = shallow(component)
-
-    const select = rendered.find('.menu-toggle')
-    select.simulate('click', { target: { blur: () => {} } })
-
-    const newMapButton = rendered.find('.menu-item.map-eichenwalde')
-    newMapButton.simulate('click', {
-      preventDefault: () => {},
-      target: { blur: () => {} }
-    })
-
-    expect(mapIDSelected).toBe(map2.id)
   })
 })

--- a/spec/javascript/components/select-menu.test.jsx
+++ b/spec/javascript/components/select-menu.test.jsx
@@ -1,0 +1,50 @@
+import renderer from 'react-test-renderer'
+import { shallow } from 'enzyme'
+
+import SelectMenu from '../../../app/assets/javascripts/components/select-menu.jsx'
+
+describe('SelectMenu', () => {
+  let component = null
+  const item1 = { id: 1, name: 'First item' }
+  let idSelected = item1.id
+  const item2 = { id: 2, name: 'Second item' }
+  const props = {
+    items: [item1, item2],
+    onChange: newID => { idSelected = newID },
+    selectedItemID: idSelected,
+    disabled: false,
+    menuClass: () => 'custom-menu-class',
+    containerClass: () => 'custom-container-class',
+    menuToggleContents: () => <span>Menu</span>,
+    menuItemClass: item => `item-${item.id}`,
+    menuItemContent: (item, isSelected) => (
+      <span className={isSelected ? 'with-selected' : ''}>
+        <span className="css-truncate">{item.name}</span>
+      </span>
+    )
+  }
+
+  beforeEach(() => {
+    component = <SelectMenu {...props} />
+  })
+
+  test('matches snapshot', () => {
+    const tree = renderer.create(component).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('can change selected item', () => {
+    const rendered = shallow(component)
+
+    const select = rendered.find('.menu-toggle')
+    select.simulate('click', { target: { blur: () => {} } })
+
+    const newHeroButton = rendered.find('.menu-item.item-2')
+    newHeroButton.simulate('click', {
+      preventDefault: () => {},
+      target: { blur: () => {} }
+    })
+
+    expect(idSelected).toBe(item2.id)
+  })
+})

--- a/spec/javascript/components/select-menu.test.jsx
+++ b/spec/javascript/components/select-menu.test.jsx
@@ -39,8 +39,8 @@ describe('SelectMenu', () => {
     const select = rendered.find('.menu-toggle')
     select.simulate('click', { target: { blur: () => {} } })
 
-    const newHeroButton = rendered.find('.menu-item.item-2')
-    newHeroButton.simulate('click', {
+    const menuItemButton = rendered.find('.menu-item.item-2')
+    menuItemButton.simulate('click', {
       preventDefault: () => {},
       target: { blur: () => {} }
     })


### PR DESCRIPTION
This doesn't change the functionality any, it's just some code clean-up so that HeroSelect and MapSelect are a bit simpler. Now they use a generic SelectMenu component. This should make it easier to make all such menus in the app more consistent in appearance and behavior, in a follow-up branch. Menus can make use of the new SelectMenu component instead of copy-pasting common functionality like `onMenuItemClick`, `handleClickOutside`, etc.

This also improves the appearance of text in the menu that is longer than the menu is wide: now menu items truncate with a `...` instead of being cut off or having the ✅ covering part of the text:

<img width="173" alt="team_composition_form_-_overwatch_team_comps" src="https://user-images.githubusercontent.com/82317/28251957-aa2e7f10-6a4e-11e7-939d-b277d9baddff.png">
